### PR TITLE
Pdo addition

### DIFF
--- a/admin/player.php
+++ b/admin/player.php
@@ -29,9 +29,9 @@ if (isset(ipTV_lib::$request['id'])) {
         $streamType = (in_array(ipTV_lib::$request['type'], array('live', 'timeshift')) ? 'hls' : preg_replace('/[^A-Za-z0-9 ]/', '', $rTokenData['container']));
 
         if (in_array(ipTV_lib::$request['type'], array('live', 'timeshift'))) {
-            $ipTV_db_admin->query('SELECT `server_id`, `on_demand` FROM `streams_servers` WHERE ((`streams_servers`.`monitor_pid` > 0 AND `streams_servers`.`pid` > 0) OR (`streams_servers`.`on_demand` = 1)) AND `stream_id` = \'%d\';', ipTV_lib::$request['id']);
+            $ipTV_db_admin->query('SELECT `server_id`, `on_demand` FROM `streams_servers` WHERE ((`streams_servers`.`monitor_pid` > 0 AND `streams_servers`.`pid` > 0) OR (`streams_servers`.`on_demand` = 1)) AND `stream_id` = ?;', ipTV_lib::$request['id']);
         } else {
-            $ipTV_db_admin->query('SELECT `server_id`, `on_demand` FROM `streams_servers` LEFT JOIN `streams` ON `streams`.`id` = `streams_servers`.`stream_id` WHERE (`streams`.`direct_source` = 0 AND `streams_servers`.`pid` > 0 AND `streams_servers`.`to_analyze` = 0 AND `streams_servers`.`stream_status` <> 1) AND `stream_id` = \'%d\';', ipTV_lib::$request['id']);
+            $ipTV_db_admin->query('SELECT `server_id`, `on_demand` FROM `streams_servers` LEFT JOIN `streams` ON `streams`.`id` = `streams_servers`.`stream_id` WHERE (`streams`.`direct_source` = 0 AND `streams_servers`.`pid` > 0 AND `streams_servers`.`to_analyze` = 0 AND `streams_servers`.`stream_status` <> 1) AND `stream_id` = ?;', ipTV_lib::$request['id']);
         }
 
         $rOnDemand = false;

--- a/crons/activity.php
+++ b/crons/activity.php
@@ -56,7 +56,7 @@ function parseLog($rFile) {
                 if ($rLine['server_id'] && $rLine['user_id'] && $rLine['stream_id'] && $rLine['user_ip']) {
                     $rUpdates[] = array($rLine['user_id'], $rLine['user_ip'], json_encode(array('date_end' => $rLine['date_end'], 'stream_id' => $rLine['stream_id'])));
                     $rLine = array_map(array($ipTV_db, 'escape'), $rLine);
-                    $rQuery .= '(' . $rLine['server_id'] . ',' . $rLine['user_id'] . ',\'' . $rLine['isp'] . '\',\'' . $rLine['external_device'] . '\',' . $rLine['stream_id'] . ',' . $rLine['date_start'] . ',\'' . $rLine['user_agent'] . '\',\'' . $rLine['user_ip'] . '\',' . $rLine['date_end'] . ',\'' . $rLine['container'] . '\',\'' . $rLine['geoip_country_code'] . '\',' . $rLine['divergence'] . '),';
+                    $rQuery .= '(' . $rLine['server_id'] . ',' . $rLine['user_id'] . ',' . $rLine['isp'] . ',' . $rLine['external_device'] . ',' . $rLine['stream_id'] . ',' . $rLine['date_start'] . ',' . $rLine['user_agent'] . ',' . $rLine['user_ip'] . ',' . $rLine['date_end'] . ',' . $rLine['container'] . ',' . $rLine['geoip_country_code'] . ',' . $rLine['divergence'] . '),';
                     $rCount++;
                 }
                 break;

--- a/crons/backups.php
+++ b/crons/backups.php
@@ -24,13 +24,13 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                 if (file_exists('/proc/' . ipTV_lib::$settings['backups_pid']) && 0 < strlen(ipTV_lib::$settings['backups_pid'])) {
                     exit();
                 }
-                $ipTV_db_admin->query('UPDATE `settings` SET `backups_pid` = \'%s\';', $rPID);
+                $ipTV_db_admin->query('UPDATE `settings` SET `backups_pid` = ?;', $rPID);
             }
 
             if (isset($rBackups) && $rBackups != 'off' || $rForce) {
                 if ($rLastBackup + $rPeriod[$rBackups] <= time() || $rForce) {
                     if (!$rForce) {
-                        $ipTV_db_admin->query('UPDATE `settings` SET `last_backup` = \'%s\';', time());
+                        $ipTV_db_admin->query('UPDATE `settings` SET `last_backup` = ?;', time());
                     }
                     $ipTV_db_admin->close_mysql();
 

--- a/crons/cache_engine.php
+++ b/crons/cache_engine.php
@@ -525,7 +525,7 @@ function generateGroups() {
     $ipTV_db->query('SELECT `group_id` FROM `member_groups`;');
     foreach ($ipTV_db->get_rows() as $rGroup) {
         $rBouquets = $rReturn = array();
-        $ipTV_db->query("SELECT * FROM `packages` WHERE JSON_CONTAINS(`groups`, '%s', '\$');", $rGroup['group_id']);
+        $ipTV_db->query("SELECT * FROM `packages` WHERE JSON_CONTAINS(`groups`, ?, '\$');", $rGroup['group_id']);
         foreach ($ipTV_db->get_rows() as $rRow) {
             foreach (json_decode($rRow['bouquets'], true) as $rID) {
                 if (!in_array($rID, $rBouquets)) {
@@ -558,7 +558,7 @@ function generateGroups() {
                 }
                 foreach (json_decode($rRow['bouquet_series'], true) as $rSeriesID) {
                     $rSeriesIDs[] = $rSeriesID;
-                    $ipTV_db->query('SELECT `stream_id` FROM `streams_episodes` WHERE `series_id` = \'%d\';', $rSeriesID);
+                    $ipTV_db->query('SELECT `stream_id` FROM `streams_episodes` WHERE `series_id` = ?;', $rSeriesID);
                     foreach ($ipTV_db->get_rows() as $rEpisode) {
                         $rStreamIDs[] = $rEpisode['stream_id'];
                     }
@@ -593,7 +593,7 @@ function generateUsersPerIP() {
     $rUsersPerIP = array(3600 => array(), 86400 => array(), 604800 => array(), 0 => array());
     foreach (array_keys($rUsersPerIP) as $rTime) {
         if (0 < $rTime) {
-            $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`user_ip`)) AS `ip_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `date_start` >= \'%s\' AND `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 GROUP BY `user_activity`.`user_id` ORDER BY `ip_count` DESC LIMIT 1000;', time() - $rTime);
+            $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`user_ip`)) AS `ip_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `date_start` >= ? AND `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 GROUP BY `user_activity`.`user_id` ORDER BY `ip_count` DESC LIMIT 1000;', time() - $rTime);
         } else {
             $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`user_ip`)) AS `ip_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 GROUP BY `user_activity`.`user_id` ORDER BY `ip_count` DESC LIMIT 1000;');
         }
@@ -608,7 +608,7 @@ function generateTheftDetection() {
     $rTheftDetection = array(3600 => array(), 86400 => array(), 604800 => array(), 0 => array());
     foreach (array_keys($rTheftDetection) as $rTime) {
         if (0 < $rTime) {
-            $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`stream_id`)) AS `vod_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `date_start` >= \'%s\' AND `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 AND `stream_id` IN (SELECT `id` FROM `streams` WHERE `type` IN (2,5)) GROUP BY `user_activity`.`user_id` ORDER BY `vod_count` DESC LIMIT 1000;', time() - $rTime);
+            $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`stream_id`)) AS `vod_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `date_start` >= ? AND `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 AND `stream_id` IN (SELECT `id` FROM `streams` WHERE `type` IN (2,5)) GROUP BY `user_activity`.`user_id` ORDER BY `vod_count` DESC LIMIT 1000;', time() - $rTime);
         } else {
             $ipTV_db->query('SELECT `user_activity`.`user_id`, COUNT(DISTINCT(`user_activity`.`stream_id`)) AS `vod_count`, `users`.`username` FROM `user_activity` LEFT JOIN `users` ON `users`.`id` = `user_activity`.`user_id` WHERE `users`.`is_mag` = 0 AND `users`.`is_e2` = 0 AND `users`.`is_restreamer` = 0 AND `stream_id` IN (SELECT `id` FROM `streams` WHERE `type` IN (2,5)) GROUP BY `user_activity`.`user_id` ORDER BY `vod_count` DESC LIMIT 1000;');
         }

--- a/crons/epg.php
+++ b/crons/epg.php
@@ -122,7 +122,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
         foreach ($ipTV_db->get_rows() as $row) {
             $dataEPG = new Epg($row["epg_file"]);
             if ($dataEPG->validEpg) {
-                $ipTV_db->query("UPDATE `epg` SET `data` = '%s' WHERE `id` = '%d'", json_encode($dataEPG->getData()), $row["id"]);
+                $ipTV_db->query("UPDATE `epg` SET `data` = ? WHERE `id` = ?", json_encode($dataEPG->getData()), $row["id"]);
                 $dataEPG = NULL;
             }
         }
@@ -130,11 +130,11 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
         $epgs = $ipTV_db->get_rows();
         foreach ($epgs as $epg) {
             if ($epg["days_keep"] == 0) {
-                $ipTV_db->query("DELETE FROM `epg_data` WHERE `epg_id` = '%d'", $epg["epg_id"]);
+                $ipTV_db->query("DELETE FROM `epg_data` WHERE `epg_id` = ?", $epg["epg_id"]);
             }
             $dataEPG = new Epg($epg["epg_file"]);
             if ($dataEPG->validEpg) {
-                $ipTV_db->query("SELECT t1.`channel_id`, t1.`epg_lang`, last_row.start FROM `streams` t1 LEFT JOIN ( SELECT channel_id, MAX(`start`) as start FROM epg_data WHERE epg_id = '%d' GROUP BY channel_id ) last_row ON last_row.channel_id = t1.channel_id WHERE `epg_id` = '%d';", $epg["epg_id"], $epg["epg_id"]);
+                $ipTV_db->query("SELECT t1.`channel_id`, t1.`epg_lang`, last_row.start FROM `streams` t1 LEFT JOIN ( SELECT channel_id, MAX(`start`) as start FROM epg_data WHERE epg_id = ? GROUP BY channel_id ) last_row ON last_row.channel_id = t1.channel_id WHERE `epg_id` = ?;", $epg["epg_id"], $epg["epg_id"]);
                 $chanel_id = $ipTV_db->get_rows(true, "channel_id");
                 $programmes = $dataEPG->getProgrammes($epg["epg_id"], $chanel_id);
                 $id = 0;
@@ -142,10 +142,10 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     $ipTV_db->query("INSERT INTO `epg_data` (`epg_id`,`channel_id`,`start`,`end`,`lang`,`title`,`description`) VALUES " . $programmes[$id]);
                     $id++;
                 }
-                $ipTV_db->query("UPDATE `epg` SET `last_updated` = '%d' WHERE `id` = '%d'", time(), $epg["epg_id"]);
+                $ipTV_db->query("UPDATE `epg` SET `last_updated` = ? WHERE `id` = ?", time(), $epg["epg_id"]);
             }
             if (0 < $epg["days_keep"]) {
-                $ipTV_db->query("DELETE FROM `epg_data` WHERE `epg_id` = '%d' AND `start` < '%s'", $epg["epg_id"], date("Y-m-d H:i:00", strtotime("-" . $epg["days_keep"] . " days")));
+                $ipTV_db->query("DELETE FROM `epg_data` WHERE `epg_id` = ? AND `start` < ?", $epg["epg_id"], date("Y-m-d H:i:00", strtotime("-" . $epg["days_keep"] . " days")));
             }
         }
         $ipTV_db->query("DELETE n1 FROM `epg_data` n1, `epg_data` n2 WHERE n1.id < n2.id AND n1.epg_id = n2.epg_id AND n1.channel_id = n2.channel_id AND n1.start = n2.start AND n1.title = n2.title");

--- a/crons/errors.php
+++ b/crons/errors.php
@@ -75,7 +75,7 @@ function loadCron() {
     }
     if (!empty($rQuery)) {
         $rQuery = rtrim($rQuery, ',');
-        $ipTV_db->query('INSERT INTO `streams_errors` (`stream_id`,`server_id`,`date`,`error`) VALUES ' . $rQuery . ';');
+        $ipTV_db->query('INSERT INTO `stream_logs` (`stream_id`,`server_id`,`date`,`error`) VALUES ' . $rQuery . ';');
     }
     $rLog = LOGS_TMP_PATH . 'error_log.log';
     if (file_exists($rLog)) {

--- a/crons/series.php
+++ b/crons/series.php
@@ -34,7 +34,7 @@ function loadCron() {
                     }
                 }
                 if ($rUpdate) {
-                    $ipTV_db_admin->query('UPDATE `streams` SET `stream_source` = \'%s\' WHERE `id` = \'%s\';', json_encode($rPlaylist['sources'], JSON_UNESCAPED_UNICODE), $rRow['id']);
+                    $ipTV_db_admin->query('UPDATE `streams` SET `stream_source` = ? WHERE `id` = ?;', json_encode($rPlaylist['sources'], JSON_UNESCAPED_UNICODE), $rRow['id']);
                     echo 'Updated: ' . $rRow['stream_display_name'] . "\n";
                 }
             }

--- a/crons/servers.php
+++ b/crons/servers.php
@@ -107,14 +107,14 @@ function loadCron() {
                 }
             }
         } else {
-            $ipTV_db->query('SELECT COUNT(*) AS `count` FROM `lines_live` WHERE `server_id` = \'%s\' AND `hls_end` = 0;', SERVER_ID);
+            $ipTV_db->query('SELECT COUNT(*) AS `count` FROM `lines_live` WHERE `server_id` = ? AND `hls_end` = 0;', SERVER_ID);
             $rConnections = intval($ipTV_db->get_row()['count']);
-            $ipTV_db->query('SELECT `activity_id` FROM `lines_live` WHERE `server_id` = \'%s\' AND `hls_end` = 0 GROUP BY `user_id`;', SERVER_ID);
+            $ipTV_db->query('SELECT `activity_id` FROM `lines_live` WHERE `server_id` = ? AND `hls_end` = 0 GROUP BY `user_id`;', SERVER_ID);
             $rUsers = intval($ipTV_db->num_rows());
             $ipTV_db->query('SELECT `activity_id` FROM `lines_live` WHERE `hls_end` = 0 GROUP BY `user_id`;');
             $rAllUsers = intval($ipTV_db->num_rows());
         }
-        $ipTV_db->query('SELECT COUNT(*) AS `count` FROM `streams_servers` LEFT JOIN `streams` ON `streams`.`id` = `streams_servers`.`stream_id` WHERE `server_id` = \'%s\' AND `pid` > 0 AND `type` = 1;', SERVER_ID);
+        $ipTV_db->query('SELECT COUNT(*) AS `count` FROM `streams_servers` LEFT JOIN `streams` ON `streams`.`id` = `streams_servers`.`stream_id` WHERE `server_id` = ? AND `pid` > 0 AND `type` = 1;', SERVER_ID);
         $rStreams = intval($ipTV_db->get_row()['count']);
         $rPing = 0;
         if (!$rServers[SERVER_ID]['is_main']) {
@@ -131,15 +131,15 @@ function loadCron() {
         }
         $rSysCtl = file_get_contents('/etc/sysctl.conf');
         $rAddresses = array_values(array_unique(array_map('trim', explode("\n", shell_exec("ip -4 addr | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}'")))));
-        // $ipTV_db->query('INSERT INTO `servers_stats`(`server_id`, `connections`, `total_users`, `users`, `streams`, `cpu`, `cpu_cores`, `cpu_avg`, `total_mem`, `total_mem_free`, `total_mem_used`, `total_mem_used_percent`, `total_disk_space`, `uptime`, `total_running_streams`, `bytes_sent`, `bytes_received`, `bytes_sent_total`, `bytes_received_total`, `cpu_load_average`, `gpu_info`, `iostat_info`, `time`) VALUES(\'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', UNIX_TIMESTAMP());', SERVER_ID, $rConnections, $rAllUsers, $rUsers, $rStreams, $rStats['cpu'], $rStats['cpu_cores'], $rStats['cpu_avg'], $rStats['total_mem'], $rStats['total_mem_free'], $rStats['total_mem_used'], $rStats['total_mem_used_percent'], $rStats['total_disk_space'], $rStats['uptime'], $rStats['total_running_streams'], $rStats['bytes_sent'], $rStats['bytes_received'], $rStats['bytes_sent_total'], $rStats['bytes_received_total'], $rStats['cpu_load_average'], json_encode($rStats['gpu_info'], JSON_UNESCAPED_UNICODE), json_encode($rStats['iostat_info'], JSON_UNESCAPED_UNICODE));
-        $ipTV_db->query('UPDATE `streaming_servers` SET `remote_status` = \'%s\', `script_version` = \'%s\', `server_hardware` = \'%s\',`whitelist_ips` = \'%s\', `sysctl` = \'%s\', `video_devices` = \'%s\', `audio_devices` = \'%s\', `gpu_info` = \'%s\', `interfaces` = \'%s\', `time_offset` = ' . intval(time()) . ' - UNIX_TIMESTAMP(), `ping` = \'%s\' WHERE `id` = \'%s\'', $rRemoteStatus, SCRIPT_VERSION, json_encode($rHardware, JSON_UNESCAPED_UNICODE), json_encode($rAddresses, JSON_UNESCAPED_UNICODE), $rSysCtl, json_encode($rStats['video_devices'], JSON_UNESCAPED_UNICODE), json_encode($rStats['audio_devices'], JSON_UNESCAPED_UNICODE), json_encode($rStats['gpu_info'], JSON_UNESCAPED_UNICODE), json_encode($rStats['interfaces'], JSON_UNESCAPED_UNICODE), $rPing, SERVER_ID);
+        // $ipTV_db->query('INSERT INTO `servers_stats`(`server_id`, `connections`, `total_users`, `users`, `streams`, `cpu`, `cpu_cores`, `cpu_avg`, `total_mem`, `total_mem_free`, `total_mem_used`, `total_mem_used_percent`, `total_disk_space`, `uptime`, `total_running_streams`, `bytes_sent`, `bytes_received`, `bytes_sent_total`, `bytes_received_total`, `cpu_load_average`, `gpu_info`, `iostat_info`, `time`) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP());', SERVER_ID, $rConnections, $rAllUsers, $rUsers, $rStreams, $rStats['cpu'], $rStats['cpu_cores'], $rStats['cpu_avg'], $rStats['total_mem'], $rStats['total_mem_free'], $rStats['total_mem_used'], $rStats['total_mem_used_percent'], $rStats['total_disk_space'], $rStats['uptime'], $rStats['total_running_streams'], $rStats['bytes_sent'], $rStats['bytes_received'], $rStats['bytes_sent_total'], $rStats['bytes_received_total'], $rStats['cpu_load_average'], json_encode($rStats['gpu_info'], JSON_UNESCAPED_UNICODE), json_encode($rStats['iostat_info'], JSON_UNESCAPED_UNICODE));
+        $ipTV_db->query('UPDATE `streaming_servers` SET `remote_status` = ?, `script_version` = ?, `server_hardware` = ?,`whitelist_ips` = ?, `sysctl` = ?, `video_devices` = ?, `audio_devices` = ?, `gpu_info` = ?, `interfaces` = ?, `time_offset` = ' . intval(time()) . ' - UNIX_TIMESTAMP(), `ping` = ? WHERE `id` = ?', $rRemoteStatus, SCRIPT_VERSION, json_encode($rHardware, JSON_UNESCAPED_UNICODE), json_encode($rAddresses, JSON_UNESCAPED_UNICODE), $rSysCtl, json_encode($rStats['video_devices'], JSON_UNESCAPED_UNICODE), json_encode($rStats['audio_devices'], JSON_UNESCAPED_UNICODE), json_encode($rStats['gpu_info'], JSON_UNESCAPED_UNICODE), json_encode($rStats['interfaces'], JSON_UNESCAPED_UNICODE), $rPing, SERVER_ID);
         if ($rServers[SERVER_ID]['is_main']) {
             foreach ($rServers as $rServerID => $rServerArray) {
                 if ($rServerArray['server_online'] != $rServerArray['last_status']) {
-                    $ipTV_db->query('UPDATE `streaming_servers` SET `last_status` = \'%s\' WHERE `id` = \'%s\';', $rServerArray['server_online'], $rServerID);
+                    $ipTV_db->query('UPDATE `streaming_servers` SET `last_status` = ? WHERE `id` = ?;', $rServerArray['server_online'], $rServerID);
                 }
             }
-            $ipTV_db->query('DELETE FROM `signals` WHERE `time` <= \'%s\';', time() - 86400);
+            $ipTV_db->query('DELETE FROM `signals` WHERE `time` <= ?;', time() - 86400);
         }
     } else {
         echo 'XtreamCodes not running...' . "\n";

--- a/crons/users.php
+++ b/crons/users.php
@@ -327,7 +327,7 @@ function loadCron() {
     if (count($rConnectionSpeeds) > 0) {
         if (ipTV_lib::$settings['redis_handler']) {
             $rStreamMap = $rBitrates = array();
-            $ipTV_db->query('SELECT `stream_id`, `bitrate` FROM `streams_servers` WHERE `server_id` = \'%d\' AND `bitrate` IS NOT NULL;', SERVER_ID);
+            $ipTV_db->query('SELECT `stream_id`, `bitrate` FROM `streams_servers` WHERE `server_id` = ? AND `bitrate` IS NOT NULL;', SERVER_ID);
             foreach ($ipTV_db->get_rows() as $rRow) {
                 $rStreamMap[intval($rRow['stream_id'])] = intval($rRow['bitrate'] / 8 * 0.92);
             }
@@ -348,7 +348,7 @@ function loadCron() {
             unset($rStreamMap);
         } else {
             $rBitrates = array();
-            $ipTV_db->query('SELECT `lines_live`.`uuid`, `streams_servers`.`bitrate` FROM `lines_live` LEFT JOIN `streams_servers` ON `lines_live`.`stream_id` = `streams_servers`.`stream_id` AND `lines_live`.`server_id` = `streams_servers`.`server_id` WHERE `lines_live`.`server_id` = \'%d\';', SERVER_ID);
+            $ipTV_db->query('SELECT `lines_live`.`uuid`, `streams_servers`.`bitrate` FROM `lines_live` LEFT JOIN `streams_servers` ON `lines_live`.`stream_id` = `streams_servers`.`stream_id` AND `lines_live`.`server_id` = `streams_servers`.`server_id` WHERE `lines_live`.`server_id` = ?;', SERVER_ID);
             foreach ($ipTV_db->get_rows() as $rRow) {
                 $rBitrates[$rRow['uuid']] = intval($rRow['bitrate'] / 8 * 0.92);
             }

--- a/crons/vod.php
+++ b/crons/vod.php
@@ -35,7 +35,7 @@ function loadCron() {
         }
     }
     $pid = ipTV_servers::getPidFromProcessName(SERVER_ID, ipTV_lib::$FFMPEG_CPU);
-    $ipTV_db->query("SELECT t1.*,t2.* FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type AND t3.live = 0 WHERE (t1.to_analyze = 1 OR t1.stream_status = 2) AND t1.server_id = '%d'", SERVER_ID);
+    $ipTV_db->query("SELECT t1.*,t2.* FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type AND t3.live = 0 WHERE (t1.to_analyze = 1 OR t1.stream_status = 2) AND t1.server_id = ?", SERVER_ID);
     if (0 < $ipTV_db->num_rows()) {
         $series_data = $ipTV_db->get_rows();
         foreach ($series_data as $data) {
@@ -76,11 +76,11 @@ function loadCron() {
                         if (!isset($movie_properties['bitrate']) && $bitrate != $movie_properties['bitrate']) {
                             $movie_properties['bitrate'] = $bitrate;
                         }
-                        $ipTV_db->query("UPDATE `streams` SET `movie_properties` = '%s' WHERE `id` = '%d'", json_encode($movie_properties), $data["stream_id"]);
-                        $ipTV_db->query("UPDATE `streams_servers` SET `bitrate` = '%d',`to_analyze` = 0,`stream_status` = 0,`stream_info` = '%s'  WHERE `server_stream_id` = '%d'", $bitrate, json_encode($stream_info), $data["server_stream_id"]);
+                        $ipTV_db->query("UPDATE `streams` SET `movie_properties` = ? WHERE `id` = ?", json_encode($movie_properties), $data["stream_id"]);
+                        $ipTV_db->query("UPDATE `streams_servers` SET `bitrate` = ?,`to_analyze` = 0,`stream_status` = 0,`stream_info` = ?  WHERE `server_stream_id` = ?", $bitrate, json_encode($stream_info), $data["server_stream_id"]);
                         echo "VALID\n";
                     } else {
-                        $ipTV_db->query("UPDATE `streams_servers` SET `to_analyze` = 0,`stream_status` = 1  WHERE `server_stream_id` = '%d'", $data["server_stream_id"]);
+                        $ipTV_db->query("UPDATE `streams_servers` SET `to_analyze` = 0,`stream_status` = 1  WHERE `server_stream_id` = ?", $data["server_stream_id"]);
                         echo "BAD MOVIE\n";
                     }
                 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -35,7 +35,7 @@ if (file_exists(MAIN_DIR . 'config')) {
     die('no config found');
 }
 
-$ipTV_db_admin = new ipTV_db($_INFO['username'], $_INFO['password'], $_INFO['database'], $_INFO['hostname'], $_INFO['port'], empty($_INFO['pconnect']) ? false : true, false);
+$ipTV_db_admin = new Database($_INFO['username'], $_INFO['password'], $_INFO['database'], $_INFO['hostname'], $_INFO['port'], empty($_INFO['pconnect']) ? false : true);
 
 if (!$db = new mysqli($_INFO["hostname"], $_INFO["username"], $_INFO["password"], $_INFO["database"], $_INFO["port"])) {
     exit("No MySQL connection!");
@@ -107,7 +107,7 @@ function getRegisteredUser($rID) {
 
 function getRegisteredUserHash($rHash) {
     global $ipTV_db_admin;
-    $ipTV_db_admin->query("SELECT * FROM `reg_users` WHERE MD5(`username`) = '%s' LIMIT 1;", $rHash);
+    $ipTV_db_admin->query("SELECT * FROM `reg_users` WHERE MD5(`username`) = ? LIMIT 1;", $rHash);
     if ($ipTV_db_admin->num_rows() == 1) {
         return $ipTV_db_admin->get_row();
     }
@@ -116,7 +116,7 @@ function getRegisteredUserHash($rHash) {
 
 function doLogin($rUsername, $rPassword) {
     global $ipTV_db_admin;
-    $ipTV_db_admin->query("SELECT `id`, `username`, `password`, `member_group_id`, `google_2fa_sec`, `status` FROM `reg_users` WHERE `username` = '%s' LIMIT 1;", $rUsername);
+    $ipTV_db_admin->query("SELECT `id`, `username`, `password`, `member_group_id`, `google_2fa_sec`, `status` FROM `reg_users` WHERE `username` = ? LIMIT 1;", $rUsername);
     if ($ipTV_db_admin->num_rows() == 1) {
         $rRow = $ipTV_db_admin->get_row();
 
@@ -146,7 +146,7 @@ function getUser($rID) {
 
 function getPermissions($rID) {
     global $ipTV_db_admin;
-    $ipTV_db_admin->query("SELECT * FROM `member_groups` WHERE `group_id` = %s;", intval($rID));
+    $ipTV_db_admin->query("SELECT * FROM `member_groups` WHERE `group_id` = ?;", intval($rID));
     if ($ipTV_db_admin->num_rows() == 1) {
         return $ipTV_db_admin->get_row();
     }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -251,7 +251,7 @@ function getIP() {
 
 function changePort_new($rServerID, $rType, $rPorts, $rReload = false) {
     global $ipTV_db_admin;
-    $ipTV_db_admin->query('INSERT INTO `signals`(`server_id`, `time`, `custom_data`) VALUES(\'%d\', \'%s\', \'%s\');', $rServerID, time(), json_encode(array('action' => 'set_port', 'type' => intval($rType), 'ports' => $rPorts, 'reload' => $rReload)));
+    $ipTV_db_admin->query('INSERT INTO `signals`(`server_id`, `time`, `custom_data`) VALUES(?, ?, ?);', $rServerID, time(), json_encode(array('action' => 'set_port', 'type' => intval($rType), 'ports' => $rPorts, 'reload' => $rReload)));
 }
 
 function scanBouquets() {
@@ -383,7 +383,7 @@ function goHome() {
 function verifyPostTable($rTable, $rData = array(), $rOnlyExisting = false) {
     global $ipTV_db_admin;
     $rReturn = array();
-    $ipTV_db_admin->query('SELECT `column_name`, `column_default`, `is_nullable`, `data_type` FROM `information_schema`.`columns` WHERE `table_schema` = (SELECT DATABASE()) AND `table_name` = \'%s\' ORDER BY `ordinal_position`;', $rTable);
+    $ipTV_db_admin->query('SELECT `column_name`, `column_default`, `is_nullable`, `data_type` FROM `information_schema`.`columns` WHERE `table_schema` = (SELECT DATABASE()) AND `table_name` = ? ORDER BY `ordinal_position`;', $rTable);
 
     foreach ($ipTV_db_admin->get_rows() as $rRow) {
         if ($rRow['column_default'] == 'NULL') {
@@ -444,7 +444,7 @@ function prepareArray($rArray) {
                 $rValue = null;
             }
         }
-        $rPlaceholder[] = '\'%s\'';
+        $rPlaceholder[] = '?';
         $rData[] = $rValue;
     }
     return array('placeholder' => implode(',', $rPlaceholder), 'columns' => implode(',', $rColumns), 'data' => $rData, 'update' => implode(',', $rUpdate));

--- a/includes/cli_tool/archive.php
+++ b/includes/cli_tool/archive.php
@@ -19,7 +19,7 @@ if (@$argc) {
         if (!file_exists(ARCHIVE_PATH . $stream_id)) {
             mkdir(ARCHIVE_PATH . $stream_id);
         }
-        $ipTV_db->query("SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t1.id = t2.stream_id AND t2.server_id = t1.tv_archive_server_id WHERE t1.`id` = '%d' AND t1.`tv_archive_server_id` = '%d' AND t1.`tv_archive_duration` > 0", $stream_id, SERVER_ID);
+        $ipTV_db->query("SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t1.id = t2.stream_id AND t2.server_id = t1.tv_archive_server_id WHERE t1.`id` = ? AND t1.`tv_archive_server_id` = ? AND t1.`tv_archive_duration` > 0", $stream_id, SERVER_ID);
         if (0 >= $ipTV_db->num_rows()) {
         } else {
             $stream = $ipTV_db->get_row();
@@ -29,7 +29,7 @@ if (@$argc) {
             if (empty($stream["pid"])) {
                 posix_kill(getmypid(), 9);
             }
-            $ipTV_db->query("UPDATE `streams` SET `tv_archive_pid` = '%d' WHERE `id` = '%d'", getmypid(), $stream_id);
+            $ipTV_db->query("UPDATE `streams` SET `tv_archive_pid` = ? WHERE `id` = ?", getmypid(), $stream_id);
             $time_last_check = time();
             $ipTV_db->close_mysql();
             delete_old_segments($stream_id, $stream["tv_archive_duration"]);

--- a/includes/cli_tool/balancer.php
+++ b/includes/cli_tool/balancer.php
@@ -70,7 +70,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                 $rPackages = array('cpufrequtils');
                 $rInstallFiles = 'https://github.com/Vateron-Media/Xtream_sub/releases/download/v' . $lastVersion . '/' . $rFiles['lb_update'];
             } else {
-                $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = \'%s\';', $rServerID);
+                $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = ?;', $rServerID);
                 echo 'Invalid type specified!' . "\n";
                 exit();
             }
@@ -112,7 +112,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     runCommand($rConn, 'sudo tar -zxvf "/tmp/sub_xui.tar.gz" -C "' . MAIN_DIR . '"');
                     runCommand($rConn, 'sudo rm -f "/tmp/sub_xui.tar.gz"');
                     if (!file_exists(MAIN_DIR . 'status')) {
-                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = \'%s\';', $rServerID);
+                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = ?;', $rServerID);
                         echo 'Failed to extract files! Exiting' . "\n";
                         exit();
                     }
@@ -233,18 +233,18 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     }
 
                     if ($rType == 1) {
-                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1, `http_broadcast_port` = \'%s\', `https_broadcast_port` = \'%s\', `total_services` = \'%s\' WHERE `id` = \'%s\';', $rHTTPPort, $rHTTPSPort, $rServices, $rServerID);
+                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1, `http_broadcast_port` = ?, `https_broadcast_port` = ?, `total_services` = ? WHERE `id` = ?;', $rHTTPPort, $rHTTPSPort, $rServices, $rServerID);
                     } else {
-                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1 WHERE `id` = \'%s\';', $rServerID);
+                        $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1 WHERE `id` = ?;', $rServerID);
                     }
                     unlink($rInstallDir . $rServerID . '.json');
                 } else {
-                    $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = \'%s\';', $rServerID);
+                    $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = ?;', $rServerID);
                     echo 'Failed to authenticate using credentials. Exiting' . "\n";
                     exit();
                 }
             } else {
-                $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = \'%s\';', $rServerID);
+                $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 4 WHERE `id` = ?;', $rServerID);
                 echo 'Failed to connect to server. Exiting' . "\n";
                 exit();
             }

--- a/includes/cli_tool/delay.php
+++ b/includes/cli_tool/delay.php
@@ -81,7 +81,7 @@ if (@$argc) {
         require str_replace('\\', '/', dirname($argv[0])) . '/../../wwwdir/init.php';
         set_time_limit(0);
 
-        $ipTV_db->query("SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = '%d' WHERE t1.id = '%d'", SERVER_ID, $stream_id);
+        $ipTV_db->query("SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = ? WHERE t1.id = ?", SERVER_ID, $stream_id);
 
         if ($ipTV_db->num_rows() > 0) {
             $stream_data = $ipTV_db->get_row();
@@ -93,7 +93,7 @@ if (@$argc) {
                 $m3uFile = DELAY_PATH . $stream_id . "_.m3u8";
                 $playlistPath = DELAY_PATH . $stream_id . "_.m3u8_old";
                 $D90a38f0f1d7f1bcd1b2eee088e76aca = $stream_data["delay_pid"];
-                $ipTV_db->query("UPDATE `streams_servers` SET delay_pid = '%d' WHERE stream_id = '%d' AND server_id = '%d'", getmypid(), $stream_id, SERVER_ID);
+                $ipTV_db->query("UPDATE `streams_servers` SET delay_pid = ? WHERE stream_id = ? AND server_id = ?", getmypid(), $stream_id, SERVER_ID);
                 $ipTV_db->close_mysql();
                 $cleanup_minutes = $stream_data["delay_minutes"] + 5;
                 shell_exec("find " . DELAY_PATH . $stream_id . "_*" . " -type f -cmin +" . $cleanup_minutes . " -delete");

--- a/includes/cli_tool/monitor.php
+++ b/includes/cli_tool/monitor.php
@@ -28,13 +28,13 @@ require str_replace('\\', '/', dirname($argv[0])) . '/../../wwwdir/init.php';
 checkRunning($streamID);
 set_time_limit(0);
 cli_set_process_title('XtreamCodes[' . $streamID . ']');
-$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = \'%d\' WHERE t1.id = \'%d\'', SERVER_ID, $streamID);
+$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = ? WHERE t1.id = ?', SERVER_ID, $streamID);
 if (($ipTV_db->num_rows() <= 0)) {
     ipTV_stream::stopStream($streamID);
     exit();
 }
 $streamInfo = $ipTV_db->get_row();
-$ipTV_db->query('UPDATE `streams_servers` SET `monitor_pid` = \'%d\' WHERE `server_stream_id` = \'%d\'', getmypid(), $streamInfo['server_stream_id']);
+$ipTV_db->query('UPDATE `streams_servers` SET `monitor_pid` = ? WHERE `server_stream_id` = ?', getmypid(), $streamInfo['server_stream_id']);
 
 if (ipTV_lib::$settings["enable_cache"]) {
     ipTV_streaming::updateStream($streamID);
@@ -60,7 +60,7 @@ if (0 >= $rParentID) {
     $rCurrentSource = 'Loopback: #' . $rParentID;
 }
 $rLastSegment = $rForceSource = null;
-$ipTV_db->query('SELECT t1.*, t2.* FROM `streams_options` t1, `streams_arguments` t2 WHERE t1.stream_id = \'%d\' AND t1.argument_id = t2.id', $streamID);
+$ipTV_db->query('SELECT t1.*, t2.* FROM `streams_options` t1, `streams_arguments` t2 WHERE t1.stream_id = ? AND t1.argument_id = t2.id', $streamID);
 $streamArguments = $ipTV_db->get_rows();
 if (!(0 < $streamInfo['delay_minutes']) && ($streamInfo['parent_id'] == 0)) {
     $rDelay = false;
@@ -288,7 +288,7 @@ if (true) {
             echo 'Segment exists!' . "\n";
             $ea6de21e70c530a9 = true;
             $rChecks = 0;
-            $ipTV_db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = \'%d\' WHERE `server_stream_id` = \'%d\'', time() - $rOffset, $streamInfo['server_stream_id']);
+            $ipTV_db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $streamInfo['server_stream_id']);
         }
         if (($rChecks == $A63c815f93524582)) {
             echo 'Reached max failures' . "\n";
@@ -318,7 +318,7 @@ if (($rParentID == 0)) {
 if ((is_numeric($rPID) && (0 < $rPID) && ipTV_streaming::isStreamRunning($rPID, $streamID))) {
     shell_exec('kill -9 ' . intval($rPID));
 }
-$ipTV_db->query('UPDATE `streams_servers` SET `pid` = null, `stream_status` = 1 WHERE `server_stream_id` = \'%d\';', $streamInfo['server_stream_id']);
+$ipTV_db->query('UPDATE `streams_servers` SET `pid` = null, `stream_status` = 1 WHERE `server_stream_id` = ?;', $streamInfo['server_stream_id']);
 if (ipTV_lib::$settings["enable_cache"]) {
     ipTV_streaming::updateStream($streamID);
 }
@@ -478,14 +478,14 @@ if (file_exists($segment)) {
 // label430:
 if (!$ea6de21e70c530a9 && $streamInfo['stream_info'] && $streamInfo['on_demand']) {
     if ($streamInfo['stream_info']) {
-        // $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = \'%s\', `compatible` = \'%s\', `audio_codec` = \'%s\', `video_codec` = \'%s\', `resolution` = \'%s\', `bitrate` = \'%s\', `stream_status` = 0, `stream_started` = \'%s\' WHERE `server_stream_id` = \'%b\'', $streamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), time() - $rOffset, $streamInfo['server_stream_id']);
-        $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = \'%s\', `bitrate` = \'%d\', `stream_status` = 0, `stream_started` = \'%d\' WHERE `server_stream_id` = \'%d\'', $streamInfo['stream_info'], intval($rBitrate), time() - $rOffset, $streamInfo['server_stream_id']);
+        // $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = \'%b\'', $streamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), time() - $rOffset, $streamInfo['server_stream_id']);
+        $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = ?, `bitrate` = ?, `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', $streamInfo['stream_info'], intval($rBitrate), time() - $rOffset, $streamInfo['server_stream_id']);
     } else {
-        $ipTV_db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_info` = NULL, `compatible` = 0, `audio_codec` = NULL, `video_codec` = NULL, `resolution` = NULL, `stream_started` = \'%d\' WHERE `server_stream_id` = \'%d\'', time() - $rOffset, $streamInfo['server_stream_id']);
+        $ipTV_db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_info` = NULL, `compatible` = 0, `audio_codec` = NULL, `video_codec` = NULL, `resolution` = NULL, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $streamInfo['server_stream_id']);
     }
 } else {
-    // $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = \'%s\', `compatible` = \'%s\', `audio_codec` = \'%s\', `video_codec` = \'%s\', `resolution` = \'%s\', `bitrate` = \'%s\', `stream_status` = 0 WHERE `server_stream_id` = \'%d\'', $streamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), $streamInfo['server_stream_id']);
-    $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = \'%s\', `bitrate` = \'%d\', `stream_status` = 0 WHERE `server_stream_id` = \'%d\'', $streamInfo['stream_info'], intval($rBitrate), $streamInfo['server_stream_id']);
+    // $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0 WHERE `server_stream_id` = ?', $streamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), $streamInfo['server_stream_id']);
+    $ipTV_db->query('UPDATE `streams_servers` SET `stream_info` = ?, `bitrate` = ?, `stream_status` = 0 WHERE `server_stream_id` = ?', $streamInfo['stream_info'], intval($rBitrate), $streamInfo['server_stream_id']);
 }
 if (ipTV_lib::$settings["enable_cache"]) {
     ipTV_streaming::updateStream($streamID);

--- a/includes/cli_tool/queue.php
+++ b/includes/cli_tool/queue.php
@@ -7,7 +7,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
         $rLastCheck = null;
         $rInterval = 60;
         $rMD5 = md5_file(__FILE__);
-        while (true) {
+        while (true && $ipTV_db->ping()) {
             if (!($rLastCheck && $rInterval > time() - $rLastCheck)) {
                 if (md5_file(__FILE__) == $rMD5) {
                     ipTV_lib::$settings = ipTV_lib::getSettings(true);
@@ -16,7 +16,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     echo 'File changed! Break.' . "\n";
                 }
             }
-            if ($ipTV_db->query("SELECT `id`, `pid` FROM `queue` WHERE `server_id` = '%d' AND `pid` IS NOT NULL AND `type` = 'movie' ORDER BY `added` ASC;", SERVER_ID)) {
+            if ($ipTV_db->query("SELECT `id`, `pid` FROM `queue` WHERE `server_id` = ? AND `pid` IS NOT NULL AND `type` = 'movie' ORDER BY `added` ASC;", SERVER_ID)) {
                 $rDelete = $rInProgress = array();
                 if ($ipTV_db->num_rows() > 0) {
                     foreach ($ipTV_db->get_rows() as $rRow) {
@@ -29,12 +29,12 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                 }
                 // $rFreeSlots = (0 < ipTV_lib::$settings['max_encode_movies'] ? intval(ipTV_lib::$settings['max_encode_movies']) - count($rInProgress) : 50);
                 // if ($rFreeSlots > 0) {
-                //     if ($ipTV_db->query("SELECT `id`, `stream_id` FROM `queue` WHERE `server_id` = '%d' AND `pid` IS NULL AND `type` = 'movie' ORDER BY `added` ASC LIMIT " . $rFreeSlots . ';', SERVER_ID)) {
+                //     if ($ipTV_db->query("SELECT `id`, `stream_id` FROM `queue` WHERE `server_id` = ? AND `pid` IS NULL AND `type` = 'movie' ORDER BY `added` ASC LIMIT " . $rFreeSlots . ';', SERVER_ID)) {
                 //         if ($ipTV_db->num_rows() > 0) {
                 //             foreach ($ipTV_db->get_rows() as $rRow) {
                 //                 $rPID = ipTV_stream::startMovie($rRow['stream_id']);
                 //                 if ($rPID) {
-                //                     $ipTV_db->query('UPDATE `queue` SET `pid` = \'%d\' WHERE `id` = \'%d\';', $rPID, $rRow['id']);
+                //                     $ipTV_db->query('UPDATE `queue` SET `pid` = ? WHERE `id` = ?;', $rPID, $rRow['id']);
                 //                 } else {
                 //                     $rDelete[] = $rRow['id'];
                 //                 }
@@ -42,7 +42,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                 //         }
                 //     }
                 // }
-                if ($ipTV_db->query("SELECT `id`, `pid` FROM `queue` WHERE `server_id` = '%d' AND `pid` IS NOT NULL AND `type` = 'channel' ORDER BY `added` ASC;", SERVER_ID)) {
+                if ($ipTV_db->query("SELECT `id`, `pid` FROM `queue` WHERE `server_id` = ? AND `pid` IS NOT NULL AND `type` = 'channel' ORDER BY `added` ASC;", SERVER_ID)) {
                     $rInProgress = array();
                     if ($ipTV_db->num_rows() > 0) {
                         foreach ($ipTV_db->get_rows() as $rRow) {
@@ -55,7 +55,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     }
                     // $rFreeSlots = (0 < ipTV_lib::$settings['max_encode_cc'] ? intval(ipTV_lib::$settings['max_encode_cc']) - count($rInProgress) : 1);
                     // if ($rFreeSlots > 0) {
-                    //     if ($ipTV_db->query("SELECT `id`, `stream_id` FROM `queue` WHERE `server_id` = '%d' AND `pid` IS NULL AND `type` = 'channel' ORDER BY `added` ASC LIMIT " . $rFreeSlots . ';', SERVER_ID)) {
+                    //     if ($ipTV_db->query("SELECT `id`, `stream_id` FROM `queue` WHERE `server_id` = ? AND `pid` IS NULL AND `type` = 'channel' ORDER BY `added` ASC LIMIT " . $rFreeSlots . ';', SERVER_ID)) {
                     //         if ($ipTV_db->num_rows() > 0) {
                     //             foreach ($ipTV_db->get_rows() as $rRow) {
                     //                 if (file_exists(CREATED_PATH . $rRow['stream_id'] . '_.create')) {
@@ -72,7 +72,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
                     //                     }
                     //                 }
                     //                 if ($rPID) {
-                    //                     $ipTV_db->query('UPDATE `queue` SET `pid` = \'%d\' WHERE `id` = \'%d\';', $rPID, $rRow['id']);
+                    //                     $ipTV_db->query('UPDATE `queue` SET `pid` = ? WHERE `id` = ?;', $rPID, $rRow['id']);
                     //                 } else {
                     //                     $rDelete[] = $rRow['id'];
                     //                 }

--- a/includes/cli_tool/signals.php
+++ b/includes/cli_tool/signals.php
@@ -5,8 +5,8 @@ if ($argc) {
     cli_set_process_title('XtreamCodes[Signal Receiver]');
     shell_exec('kill $(ps aux | grep \'Signal Receiver\' | grep -v grep | grep -v ' . getmypid() . ' | awk \'{print $2}\')');
     $rMD5 = md5_file(__FILE__);
-    while (true) {
-        if ($ipTV_db->query('SELECT `signal_id`, `pid`, `rtmp` FROM `signals` WHERE `server_id` = \'%s\' AND `pid` IS NOT NULL ORDER BY `signal_id` ASC LIMIT 100', SERVER_ID)) {
+    while (true && $ipTV_db && $ipTV_db->ping()) {
+        if ($ipTV_db->query('SELECT `signal_id`, `pid`, `rtmp` FROM `signals` WHERE `server_id` = ? AND `pid` IS NOT NULL ORDER BY `signal_id` ASC LIMIT 100', SERVER_ID)) {
             if ($ipTV_db->num_rows() > 0) {
                 $rIDs = array();
                 foreach ($ipTV_db->get_rows() as $rRow) {
@@ -24,7 +24,7 @@ if ($argc) {
                     $ipTV_db->query('DELETE FROM `signals` WHERE `signal_id` IN (' . implode(',', $rIDs) . ')');
                 }
             }
-            if ($ipTV_db->query('SELECT `signal_id`, `custom_data` FROM `signals` WHERE `server_id` = \'%s\' AND `cache` = 1 ORDER BY `signal_id` ASC LIMIT 1000;', SERVER_ID)) {
+            if ($ipTV_db->query('SELECT `signal_id`, `custom_data` FROM `signals` WHERE `server_id` = ? AND `cache` = 1 ORDER BY `signal_id` ASC LIMIT 1000;', SERVER_ID)) {
                 if ($ipTV_db->num_rows() > 0) {
                     $rDeletedLines = $rUpdatedStreams = $rUpdatedLines = $rIDs = array();
                     foreach ($ipTV_db->get_rows() as $rRow) {

--- a/includes/cli_tool/update.php
+++ b/includes/cli_tool/update.php
@@ -30,7 +30,7 @@ function loadcli() {
             fclose($rOutput);
 
             echo 'Run python update.py' . "\n";
-            $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 5 WHERE `id` = \'%s\';', SERVER_ID);
+            $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 5 WHERE `id` = ?;', SERVER_ID);
             $rCommand = 'sudo /usr/bin/python3 ' . MAIN_DIR . 'update.py > /dev/null 2>&1 &';
             shell_exec($rCommand);
             exit(1);
@@ -39,11 +39,11 @@ function loadcli() {
             if (ipTV_lib::$Servers[SERVER_ID]['is_main']) {
                 foreach (ipTV_lib::$Servers as $rServer) {
                     if ($rServer['enabled'] && $rServer['status'] == 1 && time() - $rServer['last_check_ago'] <= 180 || !$rServer['is_main']) {
-                        $ipTV_db->query('INSERT INTO `signals`(`server_id`, `time`, `custom_data`) VALUES(\'%s\', \'%s\', \'%s\');', $rServer['id'], time(), json_encode(array('action' => 'update')));
+                        $ipTV_db->query('INSERT INTO `signals`(`server_id`, `time`, `custom_data`) VALUES(?, ?, ?);', $rServer['id'], time(), json_encode(array('action' => 'update')));
                     }
                 }
             }
-            $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1, `script_version` = \'%s\' WHERE `id` = \'%s\';', SCRIPT_VERSION, SERVER_ID);
+            $ipTV_db->query('UPDATE `streaming_servers` SET `status` = 1, `script_version` = ? WHERE `id` = ?;', SCRIPT_VERSION, SERVER_ID);
 
             // // remove old script
             // if (!ipTV_lib::$Servers[SERVER_ID]['is_main']) {

--- a/includes/cli_tool/update_bd.php
+++ b/includes/cli_tool/update_bd.php
@@ -5,15 +5,27 @@ require str_replace('\\', '/', dirname($argv[0])) . '/../../wwwdir/init.php';
 $ipTV_db->query("CREATE TABLE IF NOT EXISTS `servers_stats` (`id` int(11) NOT NULL AUTO_INCREMENT, `server_id` int(11) DEFAULT '0', `connections` int(11) DEFAULT '0', `streams` int(11) DEFAULT '0', `users` int(11) DEFAULT '0', `cpu` float DEFAULT '0', `cpu_cores` int(11) DEFAULT '0', `cpu_avg` float DEFAULT '0', `total_mem` int(11) DEFAULT '0', `total_mem_free` int(11) DEFAULT '0', `total_mem_used` int(11) DEFAULT '0', `total_mem_used_percent` float DEFAULT '0', `total_disk_space` bigint(20) DEFAULT '0', `uptime` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL, `total_running_streams` int(11) DEFAULT '0', `bytes_sent` bigint(20) DEFAULT '0', `bytes_received` bigint(20) DEFAULT '0', `bytes_sent_total` bigint(128) DEFAULT '0', `bytes_received_total` bigint(128) DEFAULT '0', `cpu_load_average` float DEFAULT '0', `gpu_info` mediumtext COLLATE utf8_unicode_ci, `iostat_info` mediumtext COLLATE utf8_unicode_ci, `time` int(16) DEFAULT '0', `total_users` int(11) DEFAULT '0', PRIMARY KEY (`id`) USING BTREE) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
 $ipTV_db->query("CREATE TABLE IF NOT EXISTS `queue` (`id` int(11) NOT NULL AUTO_INCREMENT, `type` varchar(32) DEFAULT NULL, `server_id` int(11) DEFAULT NULL, `stream_id` int(11) DEFAULT NULL, `pid` int(11) DEFAULT NULL, `added` int(11) DEFAULT NULL, PRIMARY KEY (`id`) USING BTREE) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
 $ipTV_db->query("CREATE TABLE IF NOT EXISTS `rtmp_ips` (`id` int(11) NOT NULL AUTO_INCREMENT, `ip` varchar(255) DEFAULT NULL, `password` varchar(128) DEFAULT NULL, `notes` mediumtext, `push` tinyint(1) DEFAULT NULL, `pull` tinyint(1) DEFAULT NULL, PRIMARY KEY (`id`), UNIQUE KEY `ip` (`ip`)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `sysctl` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `video_devices` mediumtext COLLATE utf8_unicode_ci");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `audio_devices` mediumtext COLLATE utf8_unicode_ci");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `gpu_info` mediumtext COLLATE utf8_unicode_ci");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `limit_requests` INT(11) NULL DEFAULT '0';");
-$ipTV_db->query("ALTER TABLE streaming_servers ADD COLUMN `enable_gzip` TINYINT(1) NULL DEFAULT '0';");
-$ipTV_db->query("ALTER TABLE streams ADD COLUMN `fps_restart` tinyint(1) DEFAULT '0';");
-$ipTV_db->query("ALTER TABLE streams ADD COLUMN `vframes_server_id` int(11) DEFAULT '0';");
-$ipTV_db->query("ALTER TABLE streams ADD COLUMN `vframes_pid` int(11) DEFAULT '0';");
+
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `sysctl` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `video_devices` mediumtext COLLATE utf8_unicode_ci");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `audio_devices` mediumtext COLLATE utf8_unicode_ci");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `gpu_info` mediumtext COLLATE utf8_unicode_ci");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `limit_requests` INT(11) NULL DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `enable_gzip` TINYINT(1) NULL DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `requests_per_second` INT(11) NULL DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `connections` INT(16) NULL DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ADD COLUMN `users` INT(16) NULL DEFAULT '0';");
+
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER http_broadcast_port SET DEFAULT 25461;");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER https_broadcast_port SET DEFAULT 25463;");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER total_clients SET DEFAULT 250;");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER network_interface SET DEFAULT 'auto';");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER rtmp_port SET DEFAULT 25462;");
+$ipTV_db->query("ALTER TABLE `streaming_servers` ALTER network_guaranteed_speed SET DEFAULT 1000;");
+
+$ipTV_db->query("ALTER TABLE `streams` ADD COLUMN `fps_restart` tinyint(1) DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streams` ADD COLUMN `vframes_server_id` int(11) DEFAULT '0';");
+$ipTV_db->query("ALTER TABLE `streams` ADD COLUMN `vframes_pid` int(11) DEFAULT '0';");
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('restart_php_fpm', '1')");
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('max_encode_movies', '10')");
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('max_encode_cc', '1')");
@@ -29,12 +41,7 @@ $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('cc_time', '0'
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('recaptcha_v2_secret_key', '')");
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('recaptcha_v2_site_key', '')");
 $ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('recaptcha_enable', '0')");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER http_broadcast_port SET DEFAULT 25461;");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER https_broadcast_port SET DEFAULT 25463;");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER total_clients SET DEFAULT 250;");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER network_interface SET DEFAULT 'auto';");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER rtmp_port SET DEFAULT 25462;");
-$ipTV_db->query("ALTER TABLE streaming_servers ALTER network_guaranteed_speed SET DEFAULT 1000;");
+$ipTV_db->query("INSERT INTO `settings` (`name`, `value`) VALUES ('total_users', '0')");
 
 
 $ipTV_db->query("UPDATE `crontab` SET `filename`='series.php' WHERE `filename`='vod_cc_series.php'");

--- a/includes/cli_tool/update_bd.php
+++ b/includes/cli_tool/update_bd.php
@@ -48,7 +48,7 @@ if ($ipTV_db->num_rows() > 0) {
         $rAdminSettings[$rRow['type']] = $rRow['value'];
     }
     if (0 < strlen($rAdminSettings['recaptcha_v2_secret_key']) && 0 < strlen($rAdminSettings['recaptcha_v2_site_key'])) {
-        $ipTV_db->query('UPDATE `settings` SET `recaptcha_v2_secret_key` = \'%s\', `recaptcha_v2_site_key` = \'%s\';', $rAdminSettings['recaptcha_v2_secret_key'], $rAdminSettings['recaptcha_v2_site_key']);
+        $ipTV_db->query('UPDATE `settings` SET `recaptcha_v2_secret_key` = ?, `recaptcha_v2_site_key` = ?;', $rAdminSettings['recaptcha_v2_secret_key'], $rAdminSettings['recaptcha_v2_site_key']);
     }
 }
 

--- a/includes/cli_tool/watchdog.php
+++ b/includes/cli_tool/watchdog.php
@@ -1,70 +1,113 @@
 <?php
-if ($argc) {
-    require str_replace('\\', '/', dirname($argv[0])) . '/../../wwwdir/init.php';
-    cli_set_process_title('XtreamCodes[Server WatchDog]');
-    shell_exec('kill $(ps aux | grep \'Server WatchDog\' | grep -v grep | grep -v ' . getmypid() . " | awk '{print \$2}')");
-    $rInterval = (intval(ipTV_lib::$settings['online_capacity_interval']) ?: 10);
-    $rPrevStat = $rLastCheck = null;
-    $rMD5 = md5_file(__FILE__);
-    $rWatchdog = json_decode(ipTV_lib::$Servers[SERVER_ID]['watchdog_data'], true);
-    $rCPUAverage = ($rWatchdog['cpu_average_array'] ?: array());
-    while (true && $ipTV_db->ping()) {
-        if ($rLastCheck && $rInterval > time() - $rLastCheck) {
-            $rStats = getStats();
-            if (!$rPrevStat) {
-                $rPrevStat = file('/proc/stat');
-                sleep(2);
-            }
-            $rStat = file('/proc/stat');
-            $rInfoA = explode(' ', preg_replace('!cpu +!', '', $rPrevStat[0]));
-            $rInfoB = explode(' ', preg_replace('!cpu +!', '', $rStat[0]));
-            $rPrevStat = $rStat;
-            $rDiff = array();
-
-            $rDiff['user'] = $rInfoB[0] - $rInfoA[0];
-            $rDiff['nice'] = $rInfoB[1] - $rInfoA[1];
-            $rDiff['sys'] = $rInfoB[2] - $rInfoA[2];
-            $rDiff['idle'] = $rInfoB[3] - $rInfoA[3];
-            $rTotal = array_sum($rDiff);
-            $rCPU = array();
-            foreach ($rDiff as $x => $y) {
-                $rCPU[$x] = round($y / $rTotal * 100, 2);
-            }
-
-            $rStats['cpu'] = $rCPU['user'] + $rCPU['sys'];
-            $rCPUAverage[] = $rStats['cpu'];
-            if (count($rCPUAverage) > 30) {
-                $rCPUAverage = array_slice($rCPUAverage, count($rCPUAverage) - 30, 30);
-            }
-            $rStats['cpu_average_array'] = $rCPUAverage;
-            $rPHPPIDs = array();
-
-            exec("ps -u xtreamcodes | grep php-fpm | awk {'print \$1'}", $rPHPPIDs);
-            $rResult = $ipTV_db->query('UPDATE `streaming_servers` SET `watchdog_data` = ?, `last_check_ago` = UNIX_TIMESTAMP(), `php_pids` = ? WHERE `id` = ?;', json_encode($rStats, JSON_PARTIAL_OUTPUT_ON_ERROR), json_encode($rPHPPIDs), SERVER_ID);
-
-            if ($rResult) {
-                sleep(2);
-            } else {
-                echo 'Failed, break.' . "\n";
-            }
-            break;
+if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
+    if ($argc) {
+        require str_replace('\\', '/', dirname($argv[0])) . '/../../wwwdir/init.php';
+        shell_exec('kill $(ps aux | grep watchdog | grep -v grep | grep -v ' . getmypid() . " | awk '{print \$2}')");
+        $rInterval = (intval(ipTV_lib::$settings['online_capacity_interval']) ?: 10);
+        $rLastRequests = $rLastRequestsTime = $rPrevStat = $rLastCheck = null;
+        $rMD5 = md5_file(__FILE__);
+        if (ipTV_lib::$settings['redis_handler']) {
+            ipTV_lib::connectRedis();
         }
-        if (md5_file(__FILE__) == $rMD5) {
-            ipTV_lib::$Servers = ipTV_lib::getServers(true);
-            ipTV_lib::$settings = ipTV_lib::getSettings(true);
-            ipTV_streaming::getCapacity();
-            $rLastCheck = time();
-        } else {
-            echo 'File changed! Break.' . "\n";
+        $rWatchdog = json_decode(ipTV_lib::$Servers[SERVER_ID]['watchdog_data'], true);
+        $rCPUAverage = ($rWatchdog['cpu_average_array'] ?: array());
+        while (true && $ipTV_db->ping() && !(ipTV_lib::$settings['redis_handler'] && (!XUI::$redis || !XUI::$redis->ping()))) {
+            if ($rLastCheck && $rInterval > time() - $rLastCheck) {
+                $rNginx = explode("\n", file_get_contents('http://127.0.0.1:' . ipTV_lib::$Servers[SERVER_ID]['http_broadcast_port'] . '/nginx_status'));
+                list($rAccepted, $rHandled, $rRequests) = explode(' ', trim($rNginx[2]));
+                $rRequestsPerSecond = ($rLastRequests ? intval(floatval($rRequests - $rLastRequests) / (time() - $rLastRequestsTime)) : 0);
+                $rLastRequests = $rRequests;
+                $rLastRequestsTime = time();
+                $rStats = getStats();
+                if (!$rPrevStat) {
+                    $rPrevStat = file('/proc/stat');
+                    sleep(2);
+                }
+                $rStat = file('/proc/stat');
+                $rInfoA = explode(' ', preg_replace('!cpu +!', '', $rPrevStat[0]));
+                $rInfoB = explode(' ', preg_replace('!cpu +!', '', $rStat[0]));
+                $rPrevStat = $rStat;
+                $rDiff = array();
+                $rDiff['user'] = $rInfoB[0] - $rInfoA[0];
+                $rDiff['nice'] = $rInfoB[1] - $rInfoA[1];
+                $rDiff['sys'] = $rInfoB[2] - $rInfoA[2];
+                $rDiff['idle'] = $rInfoB[3] - $rInfoA[3];
+                $rTotal = array_sum($rDiff);
+                $rCPU = array();
+                foreach ($rDiff as $x => $y) {
+                    $rCPU[$x] = round($y / $rTotal * 100, 2);
+                }
+                $rStats['cpu'] = $rCPU['user'] + $rCPU['sys'];
+                $rCPUAverage[] = $rStats['cpu'];
+                if (count($rCPUAverage) > 30) {
+                    $rCPUAverage = array_slice($rCPUAverage, count($rCPUAverage) - 30, 30);
+                }
+                $rStats['cpu_average_array'] = $rCPUAverage;
+                $rPHPPIDs = array();
+                exec("ps -u xtreamcodes | grep php-fpm | awk {'print \$1'}", $rPHPPIDs);
+                $rConnections = $rUsers = 0;
+                if (!ipTV_lib::$settings['redis_handler']) {
+                    $ipTV_db->query('SELECT COUNT(*) AS `count` FROM `lines_live` WHERE `hls_end` = 0 AND `server_id` = ?;', SERVER_ID);
+                    $rConnections = $ipTV_db->get_row()['count'];
+                    $ipTV_db->query('SELECT `activity_id` FROM `lines_live` WHERE `hls_end` = 0 AND `server_id` = ? GROUP BY `user_id`;', SERVER_ID);
+                    $rUsers = $ipTV_db->num_rows();
+                    $rResult = $ipTV_db->query('UPDATE `streaming_servers` SET `watchdog_data` = ?, `last_check_ago` = UNIX_TIMESTAMP(), `requests_per_second` = ?, `php_pids` = ?, `connections` = ?, `users` = ? WHERE `id` = ?;', json_encode($rStats, JSON_PARTIAL_OUTPUT_ON_ERROR), $rRequestsPerSecond, json_encode($rPHPPIDs), $rConnections, $rUsers, SERVER_ID);
+                } else {
+                    $rResult = $ipTV_db->query('UPDATE `streaming_servers` SET `watchdog_data` = ?, `last_check_ago` = UNIX_TIMESTAMP(), `requests_per_second` = ?, `php_pids` = ? WHERE `id` = ?;', json_encode($rStats, JSON_PARTIAL_OUTPUT_ON_ERROR), $rRequestsPerSecond, json_encode($rPHPPIDs), SERVER_ID);
+                }
+                if ($rResult) {
+                    if (ipTV_lib::$Servers[SERVER_ID]['is_main']) {
+                        if (ipTV_lib::$settings['redis_handler']) {
+                            $rMulti = ipTV_lib::$redis->multi();
+                            foreach (array_keys(ipTV_lib::$Servers) as $rServerID) {
+                                if (ipTV_lib::$Servers[$rServerID]['server_online']) {
+                                    $rMulti->zCard('SERVER#' . $rServerID);
+                                    $rMulti->zRangeByScore('SERVER_LINES#' . $rServerID, '-inf', '+inf', array('withscores' => true));
+                                }
+                            }
+                            $rResults = $rMulti->exec();
+                            $rTotalUsers = array();
+                            $i = 0;
+                            foreach (array_keys(ipTV_lib::$Servers) as $rServerID) {
+                                if (ipTV_lib::$Servers[$rServerID]['server_online']) {
+                                    $ipTV_db->query('UPDATE `streaming_servers` SET `connections` = ?, `users` = ? WHERE `id` = ?;', $rResults[$i * 2], count(array_unique(array_values($rResults[$i * 2 + 1]))), $rServerID);
+                                    $rTotalUsers = array_merge(array_values($rResults[$i * 2 + 1]), $rTotalUsers);
+                                    $i++;
+                                }
+                            }
+                            ipTV_lib::setSettings(["total_users" => count(array_unique($rTotalUsers))]);
+                        } else {
+                            $ipTV_db->query('SELECT `activity_id` FROM `lines_live` WHERE `hls_end` = 0 GROUP BY `user_id`;');
+                            $rTotalUsers = $ipTV_db->num_rows();
+                            ipTV_lib::setSettings(["total_users" => $rTotalUsers]);
+                        }
+                    }
+                    sleep(2);
+                } else {
+                    echo 'Failed, break.' . "\n";
+                }
+                break;
+            }
+            if (ipTV_lib::isRunning()) {
+                if (md5_file(__FILE__) == $rMD5) {
+                    ipTV_lib::$Servers = ipTV_lib::getServers(true);
+                    ipTV_lib::$settings = ipTV_lib::getSettings(true);
+                    ipTV_streaming::getCapacity();
+                    $rLastCheck = time();
+                } else {
+                    echo 'File changed! Break.' . "\n";
+                }
+            } else {
+                echo 'Not running! Break.' . "\n";
+            }
         }
         if (is_object($ipTV_db)) {
             $ipTV_db->close_mysql();
         }
+        shell_exec('(sleep 1; ' . PHP_BIN . ' ' . __FILE__ . ' ) > /dev/null 2>/dev/null &');
+    } else {
+        exit(0);
     }
-    if (is_object($ipTV_db)) {
-        $ipTV_db->close_mysql();
-    }
-    shell_exec('(sleep 1; ' . PHP_BIN . ' ' . __FILE__ . ' ) > /dev/null 2>/dev/null &');
 } else {
-    exit(0);
+    exit('Please run as XtreamCodes!' . "\n");
 }

--- a/includes/cli_tool/watchdog.php
+++ b/includes/cli_tool/watchdog.php
@@ -8,7 +8,7 @@ if ($argc) {
     $rMD5 = md5_file(__FILE__);
     $rWatchdog = json_decode(ipTV_lib::$Servers[SERVER_ID]['watchdog_data'], true);
     $rCPUAverage = ($rWatchdog['cpu_average_array'] ?: array());
-    while (true) {
+    while (true && $ipTV_db->ping()) {
         if ($rLastCheck && $rInterval > time() - $rLastCheck) {
             $rStats = getStats();
             if (!$rPrevStat) {
@@ -40,7 +40,7 @@ if ($argc) {
             $rPHPPIDs = array();
 
             exec("ps -u xtreamcodes | grep php-fpm | awk {'print \$1'}", $rPHPPIDs);
-            $rResult = $ipTV_db->query('UPDATE `streaming_servers` SET `watchdog_data` = \'%s\', `last_check_ago` = UNIX_TIMESTAMP(), `php_pids` = \'%s\' WHERE `id` = \'%s\';', json_encode($rStats, JSON_PARTIAL_OUTPUT_ON_ERROR), json_encode($rPHPPIDs), SERVER_ID);
+            $rResult = $ipTV_db->query('UPDATE `streaming_servers` SET `watchdog_data` = ?, `last_check_ago` = UNIX_TIMESTAMP(), `php_pids` = ? WHERE `id` = ?;', json_encode($rStats, JSON_PARTIAL_OUTPUT_ON_ERROR), json_encode($rPHPPIDs), SERVER_ID);
 
             if ($rResult) {
                 sleep(2);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -120,7 +120,7 @@ function checkFlood($rIP = null) {
                                 if (ipTV_lib::$cached) {
                                     ipTV_lib::setSignal('flood_attack/' . $rIP, 1);
                                 } else {
-                                    $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(\'%s\',\'%s\',\'%d\')', $rIP, 'FLOOD ATTACK', time());
+                                    $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(?,?,?)', $rIP, 'FLOOD ATTACK', time());
                                 }
                                 touch(FLOOD_TMP_PATH . 'block_' . $rIP);
                             }
@@ -236,7 +236,7 @@ function checkBruteforce($rIP = null, $rMAC = null, $rUsername = null) {
                                         if (ipTV_lib::$cached) {
                                             ipTV_lib::setSignal('bruteforce_attack/' . $rIP, 1);
                                         } else {
-                                            $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(\'%s\',\'%s\',\'%s\')', $rIP, 'BRUTEFORCE ' . strtoupper($rFloodType) . ' ATTACK', time());
+                                            $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(?,?,?)', $rIP, 'BRUTEFORCE ' . strtoupper($rFloodType) . ' ATTACK', time());
                                         }
                                         touch(FLOOD_TMP_PATH . 'block_' . $rIP);
                                     }
@@ -298,14 +298,14 @@ function truncateAttempts($rAttempts, $rFrequency, $rList = false) {
 }
 function GetEPGStream($stream_id, $from_now = false) {
     global $ipTV_db;
-    $ipTV_db->query('SELECT `type`,`movie_properties`,`epg_id`,`channel_id` FROM `streams` WHERE `id` = \'%d\'', $stream_id);
+    $ipTV_db->query('SELECT `type`,`movie_properties`,`epg_id`,`channel_id` FROM `streams` WHERE `id` = ?', $stream_id);
     if ($ipTV_db->num_rows() > 0) {
         $data = $ipTV_db->get_row();
         if ($data['type'] != 2) {
             if ($from_now) {
-                $ipTV_db->query('SELECT * FROM `epg_data` WHERE `epg_id` = \'%d\' AND `channel_id` = \'%s\' AND `end` >= \'%s\'', $data['epg_id'], $data['channel_id'], date('Y-m-d H:i:00'));
+                $ipTV_db->query('SELECT * FROM `epg_data` WHERE `epg_id` = ? AND `channel_id` = ? AND `end` >= ?', $data['epg_id'], $data['channel_id'], date('Y-m-d H:i:00'));
             } else {
-                $ipTV_db->query('SELECT * FROM `epg_data` WHERE `epg_id` = \'%d\' AND `channel_id` = \'%s\'', $data['epg_id'], $data['channel_id']);
+                $ipTV_db->query('SELECT * FROM `epg_data` WHERE `epg_id` = ? AND `channel_id` = ?', $data['epg_id'], $data['channel_id']);
             }
             return $ipTV_db->get_rows();
         } else {
@@ -337,7 +337,7 @@ function getTotalTmpfs() {
 function GetCategories($type = null) {
     global $ipTV_db;
     if (is_string($type)) {
-        $ipTV_db->query('SELECT t1.* FROM `stream_categories` t1 WHERE t1.category_type = \'%s\' GROUP BY t1.id ORDER BY t1.cat_order ASC', $type);
+        $ipTV_db->query('SELECT t1.* FROM `stream_categories` t1 WHERE t1.category_type = ? GROUP BY t1.id ORDER BY t1.cat_order ASC', $type);
     } else {
         $ipTV_db->query('SELECT t1.* FROM `stream_categories` t1 ORDER BY t1.cat_order ASC');
     }
@@ -356,9 +356,9 @@ function generateUserPlaylist($rUserInfo, $rDeviceKey, $rOutputKey = 'ts', $rTyp
             $rOutputKey = 'm3u8';
         }
         if (empty($rOutputKey)) {
-            $ipTV_db->query('SELECT t1.output_ext FROM `access_output` t1 INNER JOIN `devices` t2 ON t2.default_output = t1.access_output_id AND `device_key` = \'%s\'', $rDeviceKey);
+            $ipTV_db->query('SELECT t1.output_ext FROM `access_output` t1 INNER JOIN `devices` t2 ON t2.default_output = t1.access_output_id AND `device_key` = ?', $rDeviceKey);
         } else {
-            $ipTV_db->query('SELECT t1.output_ext FROM `access_output` t1 WHERE `output_key` = \'%s\'', $rOutputKey);
+            $ipTV_db->query('SELECT t1.output_ext FROM `access_output` t1 WHERE `output_key` = ?', $rOutputKey);
         }
         if ($ipTV_db->num_rows() > 0) {
             $rCacheName = $rUserInfo['id'] . '_' . $rDeviceKey . '_' . $rOutputKey . '_' . implode('_', ($rTypeKey ?: array()));
@@ -382,7 +382,7 @@ function generateUserPlaylist($rUserInfo, $rDeviceKey, $rOutputKey = 'ts', $rTyp
                 if (empty($rOutputExt)) {
                     $rOutputExt = 'ts';
                 }
-                $ipTV_db->query('SELECT t1.*,t2.* FROM `devices` t1 LEFT JOIN `access_output` t2 ON t2.access_output_id = t1.default_output WHERE t1.device_key = \'%s\' LIMIT 1', $rDeviceKey);
+                $ipTV_db->query('SELECT t1.*,t2.* FROM `devices` t1 LEFT JOIN `access_output` t2 ON t2.access_output_id = t1.default_output WHERE t1.device_key = ? LIMIT 1', $rDeviceKey);
                 if (0 >= $ipTV_db->num_rows()) {
                     return false;
                 }
@@ -717,7 +717,7 @@ function GetContainerExtension($target_container, $stalker_container_priority = 
 }
 function searchQuery($tableName, $columnName, $value) {
     global $ipTV_db;
-    $ipTV_db->query("SELECT * FROM `{$tableName}` WHERE `{$columnName}` = '%s'", $value);
+    $ipTV_db->query("SELECT * FROM `{$tableName}` WHERE `{$columnName}` = ?", $value);
     if ($ipTV_db->num_rows() > 0) {
         return true;
     }

--- a/includes/lib.php
+++ b/includes/lib.php
@@ -281,7 +281,7 @@ class ipTV_lib {
             if (is_array($value)) {
                 $value = json_encode($value);
             }
-            if (!self::$ipTV_db->query("UPDATE `settings` SET `value` = '%s' WHERE `name` = '%s'", $value, $key)) {
+            if (!self::$ipTV_db->query("UPDATE `settings` SET `value` = ? WHERE `name` = ?", $value, $key)) {
                 return false;
             }
         }
@@ -610,7 +610,7 @@ class ipTV_lib {
         return trim($val);
     }
     public static function saveLog_old($msg) {
-        self::$ipTV_db->query('INSERT INTO `panel_logs` (`log_message`,`date`) VALUES(\'%s\',\'%d\')', $msg, time());
+        self::$ipTV_db->query('INSERT INTO `panel_logs` (`log_message`,`date`) VALUES(?,?)', $msg, time());
     }
     public static function saveLog($rType, $rMessage, $rExtra = '', $rLine = 0) {
         if (stripos($rExtra, 'panel_logs') === false && stripos($rMessage, 'timeout exceeded') === false && stripos($rMessage, 'lock wait timeout') === false && stripos($rMessage, 'duplicate entry') === false) {
@@ -721,9 +721,9 @@ class ipTV_lib {
     }
     public static function updateLine($rUserID, $rForce = false) {
         if (self::$cached) {
-            self::$ipTV_db->query('SELECT COUNT(*) AS `count` FROM `signals` WHERE `server_id` = \'%s\' AND `cache` = 1 AND `custom_data` = \'%s\';', ipTV_streaming::getMainID(), json_encode(array('type' => 'update_line', 'id' => $rUserID)));
+            self::$ipTV_db->query('SELECT COUNT(*) AS `count` FROM `signals` WHERE `server_id` = ? AND `cache` = 1 AND `custom_data` = ?;', ipTV_streaming::getMainID(), json_encode(array('type' => 'update_line', 'id' => $rUserID)));
             if (self::$ipTV_db->get_row()['count'] == 0) {
-                self::$ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(\'%s\', 1, \'%s\', \'%s\');', ipTV_streaming::getMainID(), time(), json_encode(array('type' => 'update_line', 'id' => $rUserID)));
+                self::$ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(?, 1, ?, ?);', ipTV_streaming::getMainID(), time(), json_encode(array('type' => 'update_line', 'id' => $rUserID)));
             }
             return true;
         }

--- a/includes/pdo.php
+++ b/includes/pdo.php
@@ -1,111 +1,182 @@
 <?php
 
-class ipTV_db {
-    public $result;
-    protected $last_query;
-    protected $dbuser;
-    protected $dbpassword;
-    protected $dbname;
-    protected $dbhost;
-    protected $dbport;
-    public $dbh;
+class Database {
+    public $result = null;
+    public $last_query = null;
+    protected $dbuser = null;
+    protected $dbpassword = null;
+    protected $dbname = null;
+    protected $dbhost = null;
+    protected $dbport = null;
+    public $dbh = null;
     protected $pconnect = false;
-    protected $connected = false;
+    public $connected = false;
 
     public function __construct($db_user, $db_pass, $db_name, $host, $db_port = 7999, $pconnect = false) {
-        $this->dbh = null;
+        $this->dbh = false;
         $this->dbuser = $db_user;
         $this->dbpassword = $db_pass;
         $this->dbname = $db_name;
         $this->dbhost = $host;
         $this->pconnect = $pconnect;
         $this->dbport = $db_port;
+        $this->db_connect();
     }
 
     public function close_mysql() {
-        $this->dbh = null; // Properly close the PDO connection
-        $this->connected = false;
+        if ($this->connected) {
+            $this->dbh = null; // Properly close the PDO connection
+            $this->connected = false;
+        }
+
         return true;
     }
 
-    function __destruct() {
+    public function __destruct() {
         $this->close_mysql();
     }
 
-    public function db_connect() {
-        if ($this->connected && $this->dbh) {
-            return true;
+    public function ping() {
+        try {
+            $this->dbh->query('SELECT 1');
+        } catch (Exception $e) {
+            return false;
         }
 
-        $dsn = "mysql:host={$this->dbhost};port={$this->dbport};dbname={$this->dbname};charset=utf8mb4";
+        return true;
+    }
+
+    public function db_connect() {
         $options = [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, // Enable exception-based error handling
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC, // Default fetch mode
             PDO::ATTR_PERSISTENT => $this->pconnect // Persistent connection if enabled
         ];
-
         try {
-            $this->dbh = new PDO($dsn, $this->dbuser, $this->dbpassword, $options);
-            $this->connected = true;
+            $this->dbh = new PDO("mysql:host=" . $this->dbhost . ";port=" . $this->dbport . ";dbname=" . $this->dbname . ";charset=utf8mb4", $this->dbuser, $this->dbpassword, $options);
+
+            if (!$this->dbh) {
+                return false;
+            }
         } catch (PDOException $e) {
-            $this->logError("Database connection error: " . $e->getMessage());
-            die(json_encode(["error" => "MySQL connection failed"]));
+            die(json_encode(["error" => "MySQL connection failed", "message" => $e->getMessage()]));
         }
+        $this->connected = true;
 
         return true;
     }
 
-    public function query($query, ...$params) {
-        $this->db_connect();
-        $this->last_query = $query;
-        try {
-            $this->result = $this->dbh->prepare($query);
-            $this->result->execute($params);
-        } catch (PDOException $e) {
-            $this->logError("Query error [{$query}]: " . $e->getMessage());
+    public function debugString($stmt) {
+        ob_start();
+        $stmt->debugDumpParams();
+        $r = ob_get_contents();
+        ob_end_clean();
+
+        return $r;
+    }
+
+    public function query($query, $buffered = false) {
+        if (!$this->dbh) {
             return false;
         }
+        $numargs = func_num_args();
+        $arg_list = func_get_args();
+        $next_arg_list = array();
+        $i = 1;
+
+        while ($i < $numargs) {
+            if (is_null($arg_list[$i]) || strtolower($arg_list[$i]) == 'null') {
+                $next_arg_list[] = null;
+            } else {
+                $next_arg_list[] = $arg_list[$i];
+            }
+
+            $i++;
+        }
+
+        if ($buffered === true) {
+            $this->dbh->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        }
+
+        try {
+            $this->result = $this->dbh->prepare($query);
+            $this->result->execute($next_arg_list);
+        } catch (Exception $e) {
+            $actual_query = trim(explode("\n", explode('Sent SQL:', $this->debugString($this->result))[1])[0]);
+
+            if (strlen($actual_query) == 0) {
+                $actual_query = $query;
+            }
+
+            if (class_exists('ipTV_lib')) {
+                ipTV_lib::saveLog('pdo', $e->getMessage(), $actual_query);
+            }
+
+            return false;
+        }
+
         return true;
     }
 
-    public function get_rows($use_id = false, $column_as_id = "", $unique_row = true, $column = "") {
-        if ($this->result) {
-            $rows = [];
-            $data = $this->result->fetchAll();
-            if ($use_id && $column_as_id) {
-                foreach ($data as $row) {
-                    if (!isset($rows[$row[$column_as_id]])) {
-                        $rows[$row[$column_as_id]] = $unique_row ? $row : [];
-                    }
-                    if (!$unique_row) {
-                        if (!empty($column) && isset($row[$column])) {
-                            $rows[$row[$column_as_id]][$row[$column]] = $row;
-                        } else {
-                            $rows[$row[$column_as_id]][] = $row;
-                        }
-                    }
-                }
-            } else {
-                $rows = $data;
-            }
-            return $rows;
+    public function get_rows($use_id = false, $column_as_id = '', $unique_row = true, $sub_row_id = '') {
+        if (!($this->dbh && $this->result)) {
+            return false;
         }
-        return false;
+        $rows = array();
+
+        if ($this->result->rowCount() > 0) {
+            foreach ($this->result->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                if ($use_id && array_key_exists($column_as_id, $row)) {
+                    if (!isset($rows[$row[$column_as_id]])) {
+                        $rows[$row[$column_as_id]] = array();
+                    }
+
+                    if (!$unique_row) {
+                        if (!empty($sub_row_id) && array_key_exists($sub_row_id, $row)) {
+                            $rows[$row[$column_as_id]][$row[$sub_row_id]] = $this->clean_row($row);
+                        } else {
+                            $rows[$row[$column_as_id]][] = $this->clean_row($row);
+                        }
+                    } else {
+                        $rows[$row[$column_as_id]] = $this->clean_row($row);
+                    }
+                } else {
+                    $rows[] = $this->clean_row($row);
+                }
+            }
+        }
+        $this->result = null;
+
+        return $rows;
     }
 
     public function get_row() {
-        if ($this->result) {
-            return $this->result->fetch();
+        if (!($this->dbh && $this->result)) {
+            return false;
         }
-        return false;
+        $row = array();
+
+        if ($this->result->rowCount() > 0) {
+            $row = $this->result->fetch(PDO::FETCH_ASSOC);
+        }
+        $this->result = null;
+
+        return $this->clean_row($row);
     }
 
     public function get_col() {
-        if ($this->result) {
-            $row = $this->result->fetch(PDO::FETCH_NUM);
-            return $row[0] ?? false;
+        if (!($this->dbh && $this->result)) {
+            return false;
         }
-        return false;
+        $row = false;
+
+        if ($this->result->rowCount() > 0) {
+            $row = $this->result->fetch();
+            $row = $row[0];
+        }
+        $this->result = null;
+
+        return $row;
     }
 
     public function affected_rows() {
@@ -113,35 +184,66 @@ class ipTV_db {
     }
 
     public function simple_query($query) {
-        $this->db_connect();
         try {
             $this->result = $this->dbh->query($query);
-        } catch (PDOException $e) {
-            $this->logError("Simple query error [{$query}]: " . $e->getMessage());
+        } catch (Exception $e) {
+            if (class_exists('ipTV_lib')) {
+                ipTV_lib::saveLog('pdo', $e->getMessage(), $query);
+            }
             return false;
         }
         return true;
     }
-
     public function escape($string) {
-        $this->db_connect();
-        return substr($this->dbh->quote($string), 1, -1);
+        if ($this->dbh) {
+            return $this->dbh->quote($string);
+        }
     }
 
     public function num_fields() {
-        return $this->result ? $this->result->columnCount() : 0;
+        if (!($this->dbh && $this->result)) {
+            return 0;
+        }
+        $mysqli_num_fields = $this->result->columnCount();
+        return (empty($mysqli_num_fields) ? 0 : $mysqli_num_fields);
     }
 
     public function last_insert_id() {
-        return $this->dbh ? $this->dbh->lastInsertId() : 0;
+        if ($this->dbh) {
+            $mysql_insert_id = $this->dbh->lastInsertId();
+            return (empty($mysql_insert_id) ? 0 : $mysql_insert_id);
+        }
     }
 
     public function num_rows() {
-        return $this->result ? $this->result->rowCount() : 0;
+        if (!($this->dbh && $this->result)) {
+            return 0;
+        }
+        $mysqli_num_rows = $this->result->rowCount();
+        return (empty($mysqli_num_rows) ? 0 : $mysqli_num_rows);
     }
 
-    private function logError($message) {
-        error_log("[ipTV_db Error] " . $message);
-        ipTV_lib::saveLog($message); // Assuming ipTV_lib::saveLog exists for logging
+    public static function parseCleanValue($rValue) {
+        if ($rValue != '') {
+            $rValue = str_replace(array("\r\n", "\n\r", "\r"), "\n", $rValue);
+            $rValue = str_replace('<', '&lt;', str_replace('>', '&gt;', $rValue));
+            $rValue = str_replace('<!--', '&#60;&#33;--', $rValue);
+            $rValue = str_replace('-->', '--&#62;', $rValue);
+            $rValue = str_ireplace('<script', '&#60;script', $rValue);
+            $rValue = preg_replace('/&amp;#([0-9]+);/s', '&#\\1;', $rValue);
+            $rValue = preg_replace('/&#(\\d+?)([^\\d;])/i', '&#\\1;\\2', $rValue);
+
+            return trim($rValue);
+        }
+        return '';
+    }
+
+    public function clean_row($row) {
+        foreach ($row as $key => $value) {
+            if ($value) {
+                $row[$key] = self::parseCleanValue($value);
+            }
+        }
+        return $row;
     }
 }

--- a/includes/pdo.php
+++ b/includes/pdo.php
@@ -39,7 +39,7 @@ class Database {
     public function ping() {
         try {
             $this->dbh->query('SELECT 1');
-        } catch (Exception $e) {
+        } catch (PDOException $e) {
             return false;
         }
 

--- a/includes/streaming.php
+++ b/includes/streaming.php
@@ -64,12 +64,12 @@ class ipTV_streaming {
             }
         }
         $rOutput = array();
-        self::$ipTV_db->query('SELECT * FROM `streams` t1 LEFT JOIN `streams_types` t2 ON t2.type_id = t1.type WHERE t1.`id` = \'%s\'', $streamID);
+        self::$ipTV_db->query('SELECT * FROM `streams` t1 LEFT JOIN `streams_types` t2 ON t2.type_id = t1.type WHERE t1.`id` = ?', $streamID);
         if (self::$ipTV_db->num_rows() > 0) {
             $rStreamInfo = self::$ipTV_db->get_row();
             $rServers = array();
             if ($rStreamInfo['direct_source'] == 0) {
-                self::$ipTV_db->query('SELECT * FROM `streams_servers` WHERE `stream_id` = \'%s\'', $streamID);
+                self::$ipTV_db->query('SELECT * FROM `streams_servers` WHERE `stream_id` = ?', $streamID);
                 if (self::$ipTV_db->num_rows() > 0) {
                     $rServers = self::$ipTV_db->get_rows(true, 'server_id');
                 }
@@ -277,13 +277,13 @@ class ipTV_streaming {
             }
         } else {
             if (empty($password) && empty($userID) && strlen($username) == 32) {
-                self::$ipTV_db->query('SELECT * FROM `users` WHERE `is_mag` = 0 AND `is_e2` = 0 AND `access_token` = \'%s\' AND LENGTH(`access_token`) = 32', $username);
+                self::$ipTV_db->query('SELECT * FROM `users` WHERE `is_mag` = 0 AND `is_e2` = 0 AND `access_token` = ? AND LENGTH(`access_token`) = 32', $username);
             } else {
                 if (!empty($username) && !empty($password)) {
-                    self::$ipTV_db->query('SELECT `users`.*, `mag_devices`.`token` AS `mag_token` FROM `users` LEFT JOIN `mag_devices` ON `mag_devices`.`user_id` = `users`.`id` WHERE `username` = \'%s\' AND `password` = \'%s\' LIMIT 1', $username, $password);
+                    self::$ipTV_db->query('SELECT `users`.*, `mag_devices`.`token` AS `mag_token` FROM `users` LEFT JOIN `mag_devices` ON `mag_devices`.`user_id` = `users`.`id` WHERE `username` = ? AND `password` = ? LIMIT 1', $username, $password);
                 } else {
                     if (!empty($userID)) {
-                        self::$ipTV_db->query('SELECT `users`.*, `mag_devices`.`token` AS `mag_token` FROM `users` LEFT JOIN `mag_devices` ON `mag_devices`.`user_id` = `users`.`id` WHERE `id` = \'%s\'', $userID);
+                        self::$ipTV_db->query('SELECT `users`.*, `mag_devices`.`token` AS `mag_token` FROM `users` LEFT JOIN `mag_devices` ON `mag_devices`.`user_id` = `users`.`id` WHERE `id` = ?', $userID);
                     } else {
                         return false;
                     }
@@ -301,7 +301,7 @@ class ipTV_streaming {
             if (ipTV_lib::$cached) {
                 ipTV_lib::setSignal('forced_country/' . $userInfo['id'], $userInfo['forced_country']);
             } else {
-                self::$ipTV_db->query('UPDATE `users` SET `forced_country` = \'%s\' WHERE `id` = \'%s\'', $userInfo['forced_country'], $userInfo['id']);
+                self::$ipTV_db->query('UPDATE `users` SET `forced_country` = ? WHERE `id` = ?', $userInfo['forced_country'], $userInfo['id']);
             }
         }
         $userInfo['bouquet'] = json_decode($userInfo['bouquet'], true);
@@ -355,7 +355,7 @@ class ipTV_streaming {
                 if (ipTV_lib::$cached) {
                     ipTV_lib::setSignal('isp/' . $userInfo['id'], json_encode(array($userInfo['con_isp_name'], $userInfo['isp_asn'])));
                 } else {
-                    self::$ipTV_db->query('UPDATE `users` SET `isp_desc` = \'%s\', `as_number` = \'%s\' WHERE `id` = \'%s\'', $userInfo['con_isp_name'], $userInfo['isp_asn'], $userInfo['id']);
+                    self::$ipTV_db->query('UPDATE `users` SET `isp_desc` = ?, `as_number` = ? WHERE `id` = ?', $userInfo['con_isp_name'], $userInfo['isp_asn'], $userInfo['id']);
                 }
             }
         }
@@ -421,9 +421,9 @@ class ipTV_streaming {
     }
     public static function getMagInfo($mag_id = null, $mac = null, $get_ChannelIDS = false, $getBouquetInfo = false, $get_cons = false) {
         if (empty($mag_id)) {
-            self::$ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = \'%s\'', base64_encode($mac));
+            self::$ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = ?', base64_encode($mac));
         } else {
-            self::$ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mag_id` = \'%d\'', $mag_id);
+            self::$ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mag_id` = ?', $mag_id);
         }
         if (self::$ipTV_db->num_rows() > 0) {
             $maginfo = array();
@@ -448,9 +448,9 @@ class ipTV_streaming {
     }
     public static function enigmaDevices($maginfo, $get_ChannelIDS = false, $getBouquetInfo = false, $get_cons = false) {
         if (empty($maginfo['device_id'])) {
-            self::$ipTV_db->query('SELECT * FROM `enigma2_devices` WHERE `mac` = \'%s\'', $maginfo['mac']);
+            self::$ipTV_db->query('SELECT * FROM `enigma2_devices` WHERE `mac` = ?', $maginfo['mac']);
         } else {
-            self::$ipTV_db->query('SELECT * FROM `enigma2_devices` WHERE `device_id` = \'%d\'', $maginfo['device_id']);
+            self::$ipTV_db->query('SELECT * FROM `enigma2_devices` WHERE `device_id` = ?', $maginfo['device_id']);
         }
         if (self::$ipTV_db->num_rows() > 0) {
             $enigma2devices = array();
@@ -509,7 +509,7 @@ class ipTV_streaming {
                 return null;
             }
         } else {
-            self::$ipTV_db->query('SELECT `lines_live`.*, `on_demand` FROM `lines_live` LEFT JOIN `streams_servers` ON `streams_servers`.`stream_id` = `lines_live`.`stream_id` AND `streams_servers`.`server_id` = `lines_live`.`server_id` WHERE `lines_live`.`user_id` = %d AND `lines_live`.`hls_end` = 0 ORDER BY `lines_live`.`activity_id` ASC', $userID);
+            self::$ipTV_db->query('SELECT `lines_live`.*, `on_demand` FROM `lines_live` LEFT JOIN `streams_servers` ON `streams_servers`.`stream_id` = `lines_live`.`stream_id` AND `streams_servers`.`server_id` = `lines_live`.`server_id` WHERE `lines_live`.`user_id` = ? AND `lines_live`.`hls_end` = 0 ORDER BY `lines_live`.`activity_id` ASC', $userID);
 
             $rConnectionCount = self::$ipTV_db->num_rows();
             $rToKill = $rConnectionCount - $rMaxConnections;
@@ -649,9 +649,9 @@ class ipTV_streaming {
             if (!is_array($rActivityInfo)) {
                 if (!ipTV_lib::$settings['redis_handler']) {
                     if (strlen(strval($rActivityInfo)) == 32) {
-                        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `uuid` = \'%s\'', $rActivityInfo);
+                        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `uuid` = ?', $rActivityInfo);
                     } else {
-                        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `activity_id` = \'%s\'', $rActivityInfo);
+                        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `activity_id` = ?', $rActivityInfo);
                     }
                     $rActivityInfo = self::$ipTV_db->get_row();
                 } else {
@@ -665,7 +665,7 @@ class ipTV_streaming {
                         if (ipTV_lib::$settings['redis_handler']) {
                             self::redisSignal($rActivityInfo['pid'], $rActivityInfo['server_id'], 1);
                         } else {
-                            self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`rtmp`,`time`) VALUES(\'%s\',\'%s\',\'%s\',UNIX_TIMESTAMP())', $rActivityInfo['pid'], $rActivityInfo['server_id'], 1);
+                            self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`rtmp`,`time`) VALUES(?,?,?,UNIX_TIMESTAMP())', $rActivityInfo['pid'], $rActivityInfo['server_id'], 1);
                         }
                     }
                 } else {
@@ -674,7 +674,7 @@ class ipTV_streaming {
                             if (ipTV_lib::$settings['redis_handler']) {
                                 self::updateConnection($rActivityInfo, array(), 'close');
                             } else {
-                                self::$ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `activity_id` = \'%s\'', $rActivityInfo['activity_id']);
+                                self::$ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `activity_id` = ?', $rActivityInfo['activity_id']);
                             }
                             ipTV_lib::unlinkFile(CONS_TMP_PATH . $rActivityInfo['stream_id'] . '/' . $rActivityInfo['uuid']);
                         }
@@ -687,7 +687,7 @@ class ipTV_streaming {
                             if (ipTV_lib::$settings['redis_handler']) {
                                 self::redisSignal($rActivityInfo['pid'], $rActivityInfo['server_id'], 0);
                             } else {
-                                self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`time`) VALUES(\'%s\',\'%s\',UNIX_TIMESTAMP())', $rActivityInfo['pid'], $rActivityInfo['server_id']);
+                                self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`time`) VALUES(?,?,UNIX_TIMESTAMP())', $rActivityInfo['pid'], $rActivityInfo['server_id']);
                             }
                         }
                     }
@@ -714,7 +714,7 @@ class ipTV_streaming {
                         $rRedis->sRem('ENDED', $rActivityInfo['uuid']);
                         $rRedis->exec();
                     } else {
-                        self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = \'%s\'', $rActivityInfo['activity_id']);
+                        self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = ?', $rActivityInfo['activity_id']);
                     }
                 }
                 self::writeOfflineActivity($rActivityInfo['server_id'], $rActivityInfo['user_id'], $rActivityInfo['stream_id'], $rActivityInfo['date_start'], $rActivityInfo['user_agent'], $rActivityInfo['user_ip'], $rActivityInfo['container'], $rActivityInfo['geoip_country_code'], $rActivityInfo['isp'], $rActivityInfo['external_device'], $rActivityInfo['divergence']);
@@ -725,7 +725,7 @@ class ipTV_streaming {
         return false;
     }
     public static function closeLastCon($user_id, $max_connections) {
-        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `user_id` = \'%d\' ORDER BY activity_id ASC', $user_id);
+        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `user_id` = ? ORDER BY activity_id ASC', $user_id);
         $rows = self::$ipTV_db->get_rows();
         $length = count($rows) - $max_connections + 1;
         if ($length <= 0) {
@@ -756,7 +756,7 @@ class ipTV_streaming {
             return false;
         }
         if (empty($activity_id['activity_id'])) {
-            self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `activity_id` = \'%d\'', $activity_id);
+            self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `activity_id` = ?', $activity_id);
             $activity_id = self::$ipTV_db->get_row();
         }
         if (empty($activity_id)) {
@@ -765,22 +765,22 @@ class ipTV_streaming {
         if (!($activity_id['container'] == 'rtmp')) {
             if ($activity_id['container'] == 'hls') {
                 if (!$ActionUserActivityNow) {
-                    self::$ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `activity_id` = \'%d\'', $activity_id['activity_id']);
+                    self::$ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `activity_id` = ?', $activity_id['activity_id']);
                 }
             } else {
                 if ($activity_id['server_id'] == SERVER_ID) {
                     shell_exec("kill -9 {$activity_id['pid']} >/dev/null 2>/dev/null &");
                 } else {
-                    self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`time`) VALUES(\'%d\',\'%d\',UNIX_TIMESTAMP())', $activity_id['pid'], $activity_id['server_id']);
+                    self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`time`) VALUES(?,?,UNIX_TIMESTAMP())', $activity_id['pid'], $activity_id['server_id']);
                 }
                 if ($activity_id['server_id'] == SERVER_ID) {
                     shell_exec('wget --timeout=2 -O /dev/null -o /dev/null "' . ipTV_lib::$Servers[SERVER_ID]['rtmp_mport_url'] . "control/drop/client?clientid={$activity_id['pid']}\" >/dev/null 2>/dev/null &");
                 } else {
-                    self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`rtmp`,`time`) VALUES(\'%d\',\'%d\',\'%d\',UNIX_TIMESTAMP())', $activity_id['pid'], $activity_id['server_id'], 1);
+                    self::$ipTV_db->query('INSERT INTO `signals` (`pid`,`server_id`,`rtmp`,`time`) VALUES(?,?,?,UNIX_TIMESTAMP())', $activity_id['pid'], $activity_id['server_id'], 1);
                 }
             }
             if ($ActionUserActivityNow) {
-                self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = \'%d\'', $activity_id['activity_id']);
+                self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = ?', $activity_id['activity_id']);
             }
             self::writeOfflineActivity($activity_id['server_id'], $activity_id['user_id'], $activity_id['stream_id'], $activity_id['date_start'], $activity_id['user_agent'], $activity_id['user_ip'], $activity_id['container'], $activity_id['geoip_country_code'], $activity_id['isp'], $activity_id['external_device']);
             return true;
@@ -790,10 +790,10 @@ class ipTV_streaming {
         if (empty($PID)) {
             return false;
         }
-        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `container` = \'rtmp\' AND `pid` = \'%d\' AND `server_id` = \'%d\'', $PID, SERVER_ID);
+        self::$ipTV_db->query('SELECT * FROM `lines_live` WHERE `container` = \'rtmp\' AND `pid` = ? AND `server_id` = ?', $PID, SERVER_ID);
         if (self::$ipTV_db->num_rows() > 0) {
             $activity_id = self::$ipTV_db->get_row();
-            self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = \'%d\'', $activity_id['activity_id']);
+            self::$ipTV_db->query('DELETE FROM `lines_live` WHERE `activity_id` = ?', $activity_id['activity_id']);
             self::writeOfflineActivity($activity_id['server_id'], $activity_id['user_id'], $activity_id['stream_id'], $activity_id['date_start'], $activity_id['user_agent'], $activity_id['user_ip'], $activity_id['container'], $activity_id['geoip_country_code'], $activity_id['isp'], $activity_id['external_device']);
             return true;
         }
@@ -1404,9 +1404,9 @@ class ipTV_streaming {
         return $rConnectionMap;
     }
     public static function updateStream($streamID) {
-        self::$ipTV_db->query('SELECT COUNT(*) AS `count` FROM `signals` WHERE `server_id` = \'%d\' AND `cache` = 1 AND `custom_data` = \'%s\';', self::getMainID(), json_encode(array('type' => 'update_stream', 'id' => $streamID)));
+        self::$ipTV_db->query('SELECT COUNT(*) AS `count` FROM `signals` WHERE `server_id` = ? AND `cache` = 1 AND `custom_data` = ?;', self::getMainID(), json_encode(array('type' => 'update_stream', 'id' => $streamID)));
         if (self::$ipTV_db->get_row()['count'] == 0) {
-            self::$ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(\'%s\', 1, \'%s\', \'%s\');', self::getMainID(), time(), json_encode(array('type' => 'update_stream', 'id' => $streamID)));
+            self::$ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(?, 1, ?, ?);', self::getMainID(), time(), json_encode(array('type' => 'update_stream', 'id' => $streamID)));
         }
         return true;
     }

--- a/status
+++ b/status
@@ -167,8 +167,8 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'root') {
 		}
 
 		if (!$rFirstRun && $rServers[SERVER_ID]['is_main']) {
-			$ipTV_db->query('UPDATE `streaming_servers` SET `is_main` = 0 WHERE `id` <> \'%s\';', SERVER_ID);
-			$ipTV_db->query('UPDATE `streaming_servers` SET `is_main` = 1 WHERE `id` = \'%s\';', SERVER_ID);
+			$ipTV_db->query('UPDATE `streaming_servers` SET `is_main` = 0 WHERE `id` <> ?;', SERVER_ID);
+			$ipTV_db->query('UPDATE `streaming_servers` SET `is_main` = 1 WHERE `id` = ?;', SERVER_ID);
 
 			if (stripos(ipTV_lib::$settings['server_name'], 'xtream') !== false || stripos(ipTV_lib::$settings['server_name'], 'zapx') !== false || stripos(ipTV_lib::$settings['server_name'], 'streamcreed') !== false) {
 				ipTV_lib::setSettings(["server_name" => "XtreamCodes"]);
@@ -211,7 +211,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'root') {
 			}
 		}
 
-		$ipTV_db->query('UPDATE `streaming_servers` SET `script_version` = \'%s\' WHERE `id` = \'%s\';', SCRIPT_VERSION, SERVER_ID);
+		$ipTV_db->query('UPDATE `streaming_servers` SET `script_version` = ? WHERE `id` = ?;', SCRIPT_VERSION, SERVER_ID);
 	} else {
 		exit(0);
 	}

--- a/wwwdir/admin/api.php
+++ b/wwwdir/admin/api.php
@@ -109,10 +109,10 @@ switch ($action) {
                     $user_data = empty(ipTV_lib::$request['user_data']) ? array() : ipTV_lib::$request['user_data'];
                     $user_data['is_mag'] = 1;
                     $query = GetColumnNames($user_data);
-                    if ($ipTV_db->query("UPDATE `users` SET {$query} WHERE id = ( SELECT user_id FROM mag_devices WHERE `mac` = '%s' )", base64_encode(strtoupper($mac)))) {
+                    if ($ipTV_db->query("UPDATE `users` SET {$query} WHERE id = ( SELECT user_id FROM mag_devices WHERE `mac` = ? )", base64_encode(strtoupper($mac)))) {
                         if ($ipTV_db->affected_rows() > 0) {
                             echo json_encode(array('result' => true));
-                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` ) VALUES( \'%s\', \'%s\', \'%s\', \'%s\', \'%s\' )', "SYSTEM API[{$user_ip}]", $mac, '-', time(), '[API->Edit MAG Device]');
+                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` ) VALUES( ?, ?, ?, ?, ? )', "SYSTEM API[{$user_ip}]", $mac, '-', time(), '[API->Edit MAG Device]');
                         } else {
                             echo json_encode(array('result' => false));
                         }
@@ -152,11 +152,11 @@ switch ($action) {
                             if ($ipTV_db->affected_rows() > 0) {
                                 $user_id = $ipTV_db->last_insert_id();
                                 foreach ($output_formats_types as $type) {
-                                    $ipTV_db->query('INSERT INTO `user_output` ( `user_id`, `access_output_id` )VALUES( \'%d\', \'%d\' )', $user_id, $type);
+                                    $ipTV_db->query('INSERT INTO `user_output` ( `user_id`, `access_output_id` )VALUES( ?, ? )', $user_id, $type);
                                 }
-                                $ipTV_db->query('INSERT INTO `mag_devices` ( `user_id`, `mac`, `created` )VALUES( \'%d\', \'%s\', \'%d\' )', $user_id, $mac, time());
+                                $ipTV_db->query('INSERT INTO `mag_devices` ( `user_id`, `mac`, `created` )VALUES( ?, ?, ? )', $user_id, $mac, time());
                                 echo json_encode(array('result' => true));
-                                $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( \'%s\', \'%s\', \'%s\', \'%s\', \'%s\' )', "SYSTEM API[{$user_ip}]", base64_decode($mac), '-', time(), '[API->New MAG Device]');
+                                $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( ?, ?, ?, ?, ? )', "SYSTEM API[{$user_ip}]", base64_decode($mac), '-', time(), '[API->New MAG Device]');
                             } else {
                                 echo json_encode(array('result' => false));
                             }
@@ -193,12 +193,12 @@ switch ($action) {
                     $username = ipTV_lib::$request['username'];
                     $password = ipTV_lib::$request['password'];
                     $user_data = empty(ipTV_lib::$request['user_data']) ? array() : ipTV_lib::$request['user_data'];
-                    $ipTV_db->query('SELECT * FROM `users` WHERE `username` = \'%s\' and `password` = \'%s\'', $username, $password);
+                    $ipTV_db->query('SELECT * FROM `users` WHERE `username` = ? and `password` = ?', $username, $password);
                     if ($ipTV_db->num_rows() > 0) {
                         $query = GetColumnNames($user_data);
-                        if ($ipTV_db->query("UPDATE `users` SET {$query} WHERE `username` = '%s' and `password` = '%s'", $username, $password)) {
+                        if ($ipTV_db->query("UPDATE `users` SET {$query} WHERE `username` = ? and `password` = ?", $username, $password)) {
                             echo json_encode(array('result' => true));
-                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( \'%s\', \'%s\', \'%s\', \'%s\', \'%s\' )', "SYSTEM API[{$user_ip}]", $username, $password, time(), '[API->Edit Line]');
+                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( ?, ?, ?, ?, ? )', "SYSTEM API[{$user_ip}]", $username, $password, time(), '[API->Edit Line]');
                         } else {
                             echo json_encode(array('result' => false, 'error' => 'PARAMETER ERROR'));
                         }
@@ -232,17 +232,17 @@ switch ($action) {
                 if (array_key_exists('output_formats', $user_data)) {
                     unset($user_data['output_formats']);
                 }
-                $ipTV_db->query('SELECT id FROM `users` WHERE `username` = \'%s\' AND `password` = \'%s\' LIMIT 1', $user_data['username'], $user_data['password']);
+                $ipTV_db->query('SELECT id FROM `users` WHERE `username` = ? AND `password` = ? LIMIT 1', $user_data['username'], $user_data['password']);
                 if ($ipTV_db->num_rows() == 0) {
                     $query = queryParse($user_data);
                     if ($ipTV_db->simple_query("INSERT INTO `users` {$query}")) {
                         if ($ipTV_db->affected_rows() > 0) {
                             $user_id = $ipTV_db->last_insert_id();
                             foreach ($output_formats_types as $type) {
-                                $ipTV_db->query('INSERT INTO `user_output` ( `user_id`, `access_output_id` ) VALUES( \'%d\', \'%d\' )', $user_id, $type);
+                                $ipTV_db->query('INSERT INTO `user_output` ( `user_id`, `access_output_id` ) VALUES( ?, ? )', $user_id, $type);
                             }
                             echo json_encode(array('result' => true, 'created_id' => $user_id, 'username' => $user_data['username'], 'password' => $user_data['password']));
-                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( \'%s\', \'%s\', \'%s\', \'%s\', \'%s\' )', "SYSTEM API[{$user_ip}]", $user_data['username'], $user_data['password'], time(), '[API->New Line]');
+                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( ?, ?, ?, ?, ? )', "SYSTEM API[{$user_ip}]", $user_data['username'], $user_data['password'], time(), '[API->New Line]');
                         } else {
                             echo json_encode(array('result' => false));
                         }
@@ -266,9 +266,9 @@ switch ($action) {
                 if (!empty(ipTV_lib::$request['amount']) && (!empty(ipTV_lib::$request['id']) || !empty(ipTV_lib::$request['username']))) {
                     $amount = sprintf('%.2f', ipTV_lib::$request['amount']);
                     if (!empty(ipTV_lib::$request['id'])) {
-                        $ipTV_db->query('SELECT * FROM reg_users WHERE `id` = \'%d\'', ipTV_lib::$request['id']);
+                        $ipTV_db->query('SELECT * FROM reg_users WHERE `id` = ?', ipTV_lib::$request['id']);
                     } else {
-                        $ipTV_db->query('SELECT * FROM reg_users WHERE `username` = \'%s\'', ipTV_lib::$request['username']);
+                        $ipTV_db->query('SELECT * FROM reg_users WHERE `username` = ?', ipTV_lib::$request['username']);
                     }
                     if ($ipTV_db->num_rows()) {
                         $RegUser = $ipTV_db->get_row();
@@ -276,9 +276,9 @@ switch ($action) {
                         if ($credits < 0) {
                             echo json_encode(array('result' => true, 'error' => 'NOT ENOUGH CREDITS'));
                         } else {
-                            $ipTV_db->query('UPDATE reg_users SET `credits` = \'%.2f\' WHERE `id` = \'%d\'', $credits, $RegUser['id']);
+                            $ipTV_db->query('UPDATE reg_users SET `credits` = \'%.2f\' WHERE `id` = ?', $credits, $RegUser['id']);
                             echo json_encode(array('result' => true));
-                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( \'%s\', \'%s\', \'%s\', \'%s\', \'%s\' )', "SYSTEM API[{$user_ip}]", $user_data['username'], $user_data['password'], time(), "[API->ADD Credits {$amount}]");
+                            $ipTV_db->query('INSERT INTO `reg_userlog` ( `owner`, `username`, `password`, `date`, `type` )VALUES( ?, ?, ?, ?, ? )', "SYSTEM API[{$user_ip}]", $user_data['username'], $user_data['password'], time(), "[API->ADD Credits {$amount}]");
                         }
                     } else {
                         echo json_encode(array('result' => false, 'error' => 'NOT EXISTS'));
@@ -297,7 +297,7 @@ function GetColumnNames($data) {
         $columnName = preg_replace('/[^a-zA-Z0-9\\_]+/', '', $columnName);
         if (is_array($value)) {
             $query .= "`{$columnName}` = '" . $ipTV_db->escape(json_encode($value)) . '\',';
-        } else if (is_null($value)) {
+        } elseif (is_null($value)) {
             $query .= "`{$columnName}` = null,";
         } else {
             $query .= "`{$columnName}` = '" . $ipTV_db->escape($value) . '\',';
@@ -316,7 +316,7 @@ function queryParse($data) {
     foreach (array_values($data) as $value) {
         if (is_array($value)) {
             $query .= '\'' . $ipTV_db->escape(json_encode($value)) . '\',';
-        } else if (is_null($value)) {
+        } elseif (is_null($value)) {
             $query .= 'NULL,';
         } else {
             $query .= '\'' . $ipTV_db->escape($value) . '\',';

--- a/wwwdir/admin/live.php
+++ b/wwwdir/admin/live.php
@@ -44,7 +44,7 @@ $rPassword = ipTV_lib::$settings['live_streaming_pass'];
 $rStreamID = intval(ipTV_lib::$request['stream']);
 $rExtension = ipTV_lib::$request['extension'];
 $rWaitTime = 20;
-$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = \'%s\' WHERE t1.`id` = \'%s\'', SERVER_ID, $rStreamID);
+$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.server_id = ? WHERE t1.`id` = ?', SERVER_ID, $rStreamID);
 
 if (0 < $ipTV_db->num_rows()) {
     touch(SIGNALS_TMP_PATH . 'admin_' . intval($rStreamID));

--- a/wwwdir/client_area/index.php
+++ b/wwwdir/client_area/index.php
@@ -6,7 +6,7 @@ if (!(!empty($_SESSION["client_loggedin"]) && $_SESSION["client_loggedin"] === t
     if (!(!empty(ipTV_lib::$request["username"]) && !empty(ipTV_lib::$request["password"]))) {
         goto Edca3ffe9250f93804ca6930c52ae31e;
     }
-    $ipTV_db->query("SELECT * FROM `users` WHERE `username` = '%s' AND `password` = '%s' AND (`exp_date` >= " . time() . " OR `exp_date` is null) LIMIT 1", ipTV_lib::$request["username"], ipTV_lib::$request["password"]);
+    $ipTV_db->query("SELECT * FROM `users` WHERE `username` = ? AND `password` = ? AND (`exp_date` >= " . time() . " OR `exp_date` is null) LIMIT 1", ipTV_lib::$request["username"], ipTV_lib::$request["password"]);
     if ($ipTV_db->num_rows() > 0) {
         $_SESSION["client_loggedin"] = true;
         $_SESSION["cl_data"] = $ipTV_db->get_row();

--- a/wwwdir/client_area/live.php
+++ b/wwwdir/client_area/live.php
@@ -176,7 +176,7 @@ if (!(empty($_SESSION["client_loggedin"]) && $_SESSION["client_loggedin"] != tru
                 <!--channels-->
                 <?php
                 $B9756c2ca174cd617ad8d0ed4704e5c6 = "'" . implode("','", array_unique($B9756c2ca174cd617ad8d0ed4704e5c6)) . "'";
-                $ipTV_db->query("SELECT *,UNIX_TIMESTAMP(start) as start_timestamp,UNIX_TIMESTAMP(end) as stop_timestamp from `epg_data` WHERE `end` >= '%s' AND `end` <= '%s' AND channel_id IN ({$B9756c2ca174cd617ad8d0ed4704e5c6})", date("Y-m-d H:i:00"), date("Y-m-d H:i:00", strtotime("+12 hours")));
+                $ipTV_db->query("SELECT *,UNIX_TIMESTAMP(start) as start_timestamp,UNIX_TIMESTAMP(end) as stop_timestamp from `epg_data` WHERE `end` >= ? AND `end` <= ? AND channel_id IN ({$B9756c2ca174cd617ad8d0ed4704e5c6})", date("Y-m-d H:i:00"), date("Y-m-d H:i:00", strtotime("+12 hours")));
                 $epgData = $ipTV_db->get_rows(true, "channel_id", false);
                 $C48e0083a9caa391609a3c645a2ec889 = 0;
                 if (ipTV_lib::$settings["client_area_plugin"] == "vlc") {

--- a/wwwdir/constants.php
+++ b/wwwdir/constants.php
@@ -236,9 +236,19 @@ function log_fatal() {
 }
 
 function panelLog($rType, $rMessage, $rExtra = '', $rLine = 0) {
-    $data = array('type' => $rType, 'message' => $rMessage, 'extra' => $rExtra, 'line' => $rLine, 'time' => time());
-    file_put_contents(LOGS_TMP_PATH . 'error_log.log', base64_encode(json_encode($data)) . "\n", FILE_APPEND);
+    $logFile = LOGS_TMP_PATH . 'error_log.log';
+    // Ensure directory exists
+    if (!is_dir(LOGS_TMP_PATH)) {
+        mkdir(LOGS_TMP_PATH, 0775, true);
+    }
+    $data = ['type' => $rType,
+        'message' => $rMessage, 'extra' => $rExtra,
+        'line' => $rLine, 'time' => time()
+    ];
+    // Write log
+    file_put_contents($logFile, base64_encode(json_encode($data)) . "\n", FILE_APPEND);
 }
+
 
 function generateError($rError, $rKill = true, $rCode = null) {
     global $rErrorCodes;

--- a/wwwdir/enigma2.php
+++ b/wwwdir/enigma2.php
@@ -143,7 +143,7 @@ if ($user_infos = ipTV_streaming::getUserInfo(null, $username, $password, true, 
             break;
         case 'get_seasons':
             if (isset($series_id)) {
-                $ipTV_db->query('SELECT * FROM `series` WHERE `id` = \'%d\'', $series_id);
+                $ipTV_db->query('SELECT * FROM `series` WHERE `id` = ?', $series_id);
                 $serie = $ipTV_db->get_row();
                 $category_name = $serie['title'];
                 $xml = new SimpleXMLExtended('<items/>');
@@ -151,7 +151,7 @@ if ($user_infos = ipTV_streaming::getUserInfo(null, $username, $password, true, 
                 $category = $xml->addchild('category');
                 $category->addchild('category_id', 1);
                 $category->addchild('category_title', "TV Series [ {$category_name} ]");
-                $ipTV_db->query('SELECT * FROM `series_episodes` t1 INNER JOIN `streams` t2 ON t2.id=t1.stream_id WHERE t1.series_id = \'%d\' ORDER BY t1.season_num ASC, t1.sort ASC', $series_id);
+                $ipTV_db->query('SELECT * FROM `series_episodes` t1 INNER JOIN `streams` t2 ON t2.id=t1.stream_id WHERE t1.series_id = ? ORDER BY t1.season_num ASC, t1.sort ASC', $series_id);
                 $rows = $ipTV_db->get_rows(true, 'season_num', false);
                 foreach (array_keys($rows) as $category_id) {
                     if ($cat_id != 0) {
@@ -212,7 +212,7 @@ if ($user_infos = ipTV_streaming::getUserInfo(null, $username, $password, true, 
                             continue;
                         }
                     }
-                    $ipTV_db->query('SELECT *,UNIX_TIMESTAMP(start) as start_timestamp, UNIX_TIMESTAMP(end) as stop_timestamp FROM `epg_data` WHERE `channel_id` = \'%s\' AND  `end` >= \'%s\' LIMIT 2', $user_info['channel_id'], date('Y-m-d H:i:00'));
+                    $ipTV_db->query('SELECT *,UNIX_TIMESTAMP(start) as start_timestamp, UNIX_TIMESTAMP(end) as stop_timestamp FROM `epg_data` WHERE `channel_id` = ? AND  `end` >= ? LIMIT 2', $user_info['channel_id'], date('Y-m-d H:i:00'));
                     $epgData = $ipTV_db->get_rows();
                     $desc = '';
                     $title = '';

--- a/wwwdir/init.php
+++ b/wwwdir/init.php
@@ -36,7 +36,7 @@ if (file_exists(MAIN_DIR . 'config')) {
     die('no config found');
 }
 
-$ipTV_db = new ipTV_db($_INFO['username'], $_INFO['password'], $_INFO['database'], $_INFO['hostname'], $_INFO['port'], empty($_INFO['pconnect']) ? false : true, false);
+$ipTV_db = new Database($_INFO['username'], $_INFO['password'], $_INFO['database'], $_INFO['hostname'], $_INFO['port'], empty($_INFO['pconnect']) ? false : true);
 
 ipTV_lib::$ipTV_db = &$ipTV_db;
 ipTV_streaming::$ipTV_db = &$ipTV_db;

--- a/wwwdir/player_api.php
+++ b/wwwdir/player_api.php
@@ -367,7 +367,7 @@ if ($rUserInfo) {
                 $rWhereV = $rWhere = array();
 
                 if (!empty($rCategoryIDSearch)) {
-                    $rWhere[] = "JSON_CONTAINS(`category_id`, '%s', '\$')";
+                    $rWhere[] = "JSON_CONTAINS(`category_id`, ?, '\$')";
                     $rWhereV[] = $rCategoryIDSearch;
                 }
 
@@ -413,7 +413,7 @@ if ($rUserInfo) {
             if (!empty(ipTV_lib::$request['vod_id'])) {
                 $rVODID = intval(ipTV_lib::$request['vod_id']);
 
-                $ipTV_db->query('SELECT * FROM `streams` WHERE `id` = \'%s\'', $rVODID);
+                $ipTV_db->query('SELECT * FROM `streams` WHERE `id` = ?', $rVODID);
                 $rRow = $ipTV_db->get_row();
 
                 if ($rRow) {
@@ -470,7 +470,7 @@ if ($rUserInfo) {
                 $rWhereV = $rWhere = array();
 
                 if (!empty($rCategoryIDSearch)) {
-                    $rWhere[] = "JSON_CONTAINS(`category_id`, '%s', '\$')";
+                    $rWhere[] = "JSON_CONTAINS(`category_id`, ?, '\$')";
                     $rWhereV[] = $rCategoryIDSearch;
                 }
 

--- a/wwwdir/portal.php
+++ b/wwwdir/portal.php
@@ -153,8 +153,8 @@ if ($rReqType == 'stb' && $rReqAction == 'handshake') {
         $rDevice['token'] = strtoupper(md5(uniqid(rand(), true)));
         $rVerifyToken = encryptData(igbinary_serialize(array('id' => $rDevice['mag_id'], 'token' => $rDevice['token'])), ipTV_lib::$settings['live_streaming_pass'], OPENSSL_EXTRA);
         $rDevice['authenticated'] = false;
-        $ipTV_db->query('UPDATE `mag_devices` SET `token` = \'%s\' WHERE `mag_id` = \'%s\'', $rDevice['token'], $rDevice['mag_id']);
-        $ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(\'%s\', 1, \'%s\', \'%s\');', SERVER_ID, time(), json_encode(array('type' => 'update_line', 'id' => $rDevice['user_id'])));
+        $ipTV_db->query('UPDATE `mag_devices` SET `token` = ? WHERE `mag_id` = ?', $rDevice['token'], $rDevice['mag_id']);
+        $ipTV_db->query('INSERT INTO `signals`(`server_id`, `cache`, `time`, `custom_data`) VALUES(?, 1, ?, ?);', SERVER_ID, time(), json_encode(array('type' => 'update_line', 'id' => $rDevice['user_id'])));
         updatecache();
     } else {
         $rDevice = array();
@@ -213,7 +213,7 @@ if ($rDevice && $rReqType == 'stb' && $rReqAction == 'get_profile') {
     if (empty($rSerialNumber)) {
         $rBanData = array('ip' => $rIP, 'notes' => "[MS] No Serial Number", 'date' => time());
         touch(FLOOD_TMP_PATH . 'block_' . $rIP);
-        $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(\'%s\', \'%s\', \'%s\')', $rBanData['ip'], $rBanData['notes'], $rBanData['date']);
+        $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(?, ?, ?)', $rBanData['ip'], $rBanData['notes'], $rBanData['date']);
         http_response_code(404);
         die();
     }
@@ -221,7 +221,7 @@ if ($rDevice && $rReqType == 'stb' && $rReqAction == 'get_profile') {
     if (!empty($rDevice['sn']) && $rDevice['sn'] !== $rSerialNumber) {
         $rBanData = array('ip' => $rIP, 'notes' => "[MS] Invalid Serial Number", 'date' => time());
         touch(FLOOD_TMP_PATH . 'block_' . $rIP);
-        $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(\'%s\', \'%s\', \'%s\')', $rBanData['ip'], $rBanData['notes'], $rBanData['date']);
+        $ipTV_db->query('INSERT INTO `blocked_ips` (`ip`,`notes`,`date`) VALUES(?, ?, ?)', $rBanData['ip'], $rBanData['notes'], $rBanData['date']);
         http_response_code(404);
         die();
     }
@@ -268,7 +268,7 @@ if ($rDevice && $rReqType == 'stb' && $rReqAction == 'get_profile') {
         $rDevice['get_profile_vars']['stb_type'] = $rSTBType;
         $rDevice['get_profile_vars']['hw_version'] = $rHWVersion;
         $rDevice['authenticated'] = true;
-        $ipTV_db->query('UPDATE `mag_devices` SET `ip` = \'%s\', `stb_type` = \'%s\', `sn` = \'%s\', `ver` = \'%s\', `image_version` = \'%s\', `device_id` = \'%s\', `device_id2` = \'%s\', `hw_version` = \'%s\' WHERE `mag_id` = \'%s\';', $rIP, $rSTBType, $rSerialNumber, $rVersion, $rImageVersion, $rDeviceID, $rDeviceID2, $rHWVersion, $rDevice['mag_id']);
+        $ipTV_db->query('UPDATE `mag_devices` SET `ip` = ?, `stb_type` = ?, `sn` = ?, `ver` = ?, `image_version` = ?, `device_id` = ?, `device_id2` = ?, `hw_version` = ? WHERE `mag_id` = ?;', $rIP, $rSTBType, $rSerialNumber, $rVersion, $rImageVersion, $rDeviceID, $rDeviceID2, $rHWVersion, $rDevice['mag_id']);
         updatecache();
     } else {
         ipTV_lib::unlinkFile(STALKER_TMP_PATH . 'stalker_' . $rDevice['id']);
@@ -367,7 +367,7 @@ switch ($rReqType) {
                             }
 
                             $rDevice['volume'] = $rVolume;
-                            $ipTV_db->query('UPDATE `mag_devices` SET `volume` = \'%s\' WHERE `mag_id` = \'%s\'', $rVolume, $rDevice['mag_id']);
+                            $ipTV_db->query('UPDATE `mag_devices` SET `volume` = ? WHERE `mag_id` = ?', $rVolume, $rDevice['mag_id']);
                             updatecache();
 
                             exit(json_encode(array('data' => true)));
@@ -379,7 +379,7 @@ switch ($rReqType) {
                             exit(json_encode(array('js' => $rImages)));
 
                         case 'get_settings_profile':
-                            $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mag_id` = \'%s\'', $rDevice['mag_id']);
+                            $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mag_id` = ?', $rDevice['mag_id']);
                             $rInfo = $ipTV_db->get_row();
                             $rSettings = array('js' => array('modules' => array(array('name' => 'lock'), array('name' => 'lang'), array('name' => 'update'), array('name' => 'net_info', 'sub' => array(array('name' => 'wired'), array('name' => 'pppoe', 'sub' => array(array('name' => 'dhcp'), array('name' => 'dhcp_manual'), array('name' => 'disable'))), array('name' => 'wireless'), array('name' => 'speed'))), array('name' => 'video'), array('name' => 'audio'), array('name' => 'net', 'sub' => array(array('name' => 'ethernet', 'sub' => array(array('name' => 'dhcp'), array('name' => 'dhcp_manual'), array('name' => 'manual'), array('name' => 'no_ip'))), array('name' => 'pppoe', 'sub' => array(array('name' => 'dhcp'), array('name' => 'dhcp_manual'), array('name' => 'disable'))), array('name' => 'wifi', 'sub' => array(array('name' => 'dhcp'), array('name' => 'dhcp_manual'), array('name' => 'manual'))), array('name' => 'speed'))), array('name' => 'advanced'), array('name' => 'dev_info'), array('name' => 'reload'), array('name' => 'internal_portal'), array('name' => 'reboot'))));
                             $rSettings['js']['parent_password'] = $rInfo['parent_password'];
@@ -412,7 +412,7 @@ switch ($rReqType) {
                             exit(json_encode($rSettings));
 
                         case 'get_locales':
-                            $ipTV_db->query('SELECT `locale` FROM `mag_devices` WHERE `mag_id` = \'%s\'', $rDevice['mag_id']);
+                            $ipTV_db->query('SELECT `locale` FROM `mag_devices` WHERE `mag_id` = ?', $rDevice['mag_id']);
                             $rSelected = $ipTV_db->get_row();
                             $rOutput = array();
 
@@ -431,12 +431,12 @@ switch ($rReqType) {
 
                             if (empty($rDeviceAspect)) {
                                 $rDevice['aspect'] = array('js' => array($rChannelID => $rAspect));
-                                $ipTV_db->query('UPDATE `mag_devices` SET `aspect` = \'%s\' WHERE mag_id = \'%s\'', json_encode(array('js' => array($rChannelID => $rAspect))), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `aspect` = ? WHERE mag_id = ?', json_encode(array('js' => array($rChannelID => $rAspect))), $rDevice['mag_id']);
                             } else {
                                 $rDeviceAspect = json_decode($rDeviceAspect, true);
                                 $rDeviceAspect['js'][$rChannelID] = $rAspect;
                                 $rDevice['aspect'] = $rDeviceAspect;
-                                $ipTV_db->query('UPDATE `mag_devices` SET `aspect` = \'%s\' WHERE mag_id = \'%s\'', json_encode($rDeviceAspect), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `aspect` = ? WHERE mag_id = ?', json_encode($rDeviceAspect), $rDevice['mag_id']);
                             }
 
                             updatecache();
@@ -450,7 +450,7 @@ switch ($rReqType) {
                             if (!empty($_SERVER['HTTP_COOKIE'])) {
                                 $rDelay = intval(ipTV_lib::$request['screensaver_delay']);
                                 $rDevice['screensaver_delay'] = $rDelay;
-                                $ipTV_db->query('UPDATE `mag_devices` SET `screensaver_delay` = \'%s\' WHERE `mag_id` = \'%s\'', $rDelay, $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `screensaver_delay` = ? WHERE `mag_id` = ?', $rDelay, $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -462,7 +462,7 @@ switch ($rReqType) {
                                 $rBufferSize = intval(ipTV_lib::$request['playback_buffer_size']);
                                 $rDevice['playback_buffer_bytes'] = $rBufferBytes;
                                 $rDevice['playback_buffer_size'] = $rBufferSize;
-                                $ipTV_db->query('UPDATE `mag_devices` SET `playback_buffer_bytes` = \'%s\' , `playback_buffer_size` = \'%s\' WHERE `mag_id` = \'%s\'', $rBufferBytes, $rBufferSize, $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `playback_buffer_bytes` = ? , `playback_buffer_size` = ? WHERE `mag_id` = ?', $rBufferBytes, $rBufferSize, $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -471,7 +471,7 @@ switch ($rReqType) {
                         case 'set_plasma_saving':
                             $rPlasmaSaving = intval(ipTV_lib::$request['plasma_saving']);
                             $rDevice['plasma_saving'] = $rPlasmaSaving;
-                            $ipTV_db->query('UPDATE `mag_devices` SET `plasma_saving` = \'%s\' WHERE `mag_id` = \'%s\'', $rPlasmaSaving, $rDevice['mag_id']);
+                            $ipTV_db->query('UPDATE `mag_devices` SET `plasma_saving` = ? WHERE `mag_id` = ?', $rPlasmaSaving, $rDevice['mag_id']);
                             updatecache();
 
                             exit(json_encode(array('js' => true)));
@@ -479,7 +479,7 @@ switch ($rReqType) {
                         case 'set_parent_password':
                             if (isset(ipTV_lib::$request['parent_password']) && isset(ipTV_lib::$request['pass']) && isset(ipTV_lib::$request['repeat_pass']) && ipTV_lib::$request['pass'] == ipTV_lib::$request['repeat_pass']) {
                                 $rDevice['parent_password'] = ipTV_lib::$request['pass'];
-                                $ipTV_db->query('UPDATE `mag_devices` SET `parent_password` = \'%s\' WHERE `mag_id` = \'%s\'', ipTV_lib::$request['pass'], $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `parent_password` = ? WHERE `mag_id` = ?', ipTV_lib::$request['pass'], $rDevice['mag_id']);
                                 updatecache();
 
                                 exit(json_encode(array('js' => true)));
@@ -490,7 +490,7 @@ switch ($rReqType) {
                         case 'set_locale':
                             if (!empty(ipTV_lib::$request['locale'])) {
                                 $rDevice['locale'] = ipTV_lib::$request['locale'];
-                                $ipTV_db->query('UPDATE `mag_devices` SET `locale` = \'%s\' WHERE `mag_id` = \'%s\'', ipTV_lib::$request['locale'], $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `locale` = ? WHERE `mag_id` = ?', ipTV_lib::$request['locale'], $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -500,7 +500,7 @@ switch ($rReqType) {
                             if (!empty($_SERVER['HTTP_COOKIE']) || isset(ipTV_lib::$request['data'])) {
                                 $rReaction = ipTV_lib::$request['data'];
                                 $rDevice['hdmi_event_reaction'] = $rReaction;
-                                $ipTV_db->query('UPDATE `mag_devices` SET `hdmi_event_reaction` = \'%s\' WHERE `mag_id` = \'%s\'', $rReaction, $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `hdmi_event_reaction` = ? WHERE `mag_id` = ?', $rReaction, $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -511,23 +511,23 @@ switch ($rReqType) {
 
                 case 'watchdog':
                     $rDevice['last_watchdog'] = time();
-                    $ipTV_db->query('UPDATE `mag_devices` SET `last_watchdog` = \'%s\' WHERE `mag_id` = \'%s\'', time(), $rDevice['mag_id']);
+                    $ipTV_db->query('UPDATE `mag_devices` SET `last_watchdog` = ? WHERE `mag_id` = ?', time(), $rDevice['mag_id']);
                     updatecache();
 
                     switch ($rReqAction) {
                         case 'get_events':
-                            $ipTV_db->query('SELECT * FROM `mag_events` WHERE `mag_device_id` = \'%s\' AND `status` = 0 ORDER BY `id` ASC LIMIT 1', $rDevice['mag_id']);
+                            $ipTV_db->query('SELECT * FROM `mag_events` WHERE `mag_device_id` = ? AND `status` = 0 ORDER BY `id` ASC LIMIT 1', $rDevice['mag_id']);
                             $rData = array('data' => array('msgs' => 0, 'additional_services_on' => 1));
 
                             if ($ipTV_db->num_rows() > 0) {
                                 $rEvents = $ipTV_db->get_row();
-                                $ipTV_db->query('SELECT count(*) FROM `mag_events` WHERE `mag_device_id` = \'%s\' AND `status` = 0 ', $rDevice['mag_id']);
+                                $ipTV_db->query('SELECT count(*) FROM `mag_events` WHERE `mag_device_id` = ? AND `status` = 0 ', $rDevice['mag_id']);
                                 $rMessages = $ipTV_db->get_col();
                                 $rData = array('data' => array('msgs' => $rMessages, 'id' => $rEvents['id'], 'event' => $rEvents['event'], 'need_confirm' => $rEvents['need_confirm'], 'msg' => $rEvents['msg'], 'reboot_after_ok' => $rEvents['reboot_after_ok'], 'auto_hide_timeout' => $rEvents['auto_hide_timeout'], 'send_time' => date('d-m-Y H:i:s', $rEvents['send_time']), 'additional_services_on' => $rEvents['additional_services_on'], 'updated' => array('anec' => $rEvents['anec'], 'vclub' => $rEvents['vclub'])));
                                 $rAutoStatus = array('reboot', 'reload_portal', 'play_channel', 'cut_off');
 
                                 if (in_array($rEvents['event'], $rAutoStatus)) {
-                                    $ipTV_db->query('UPDATE `mag_events` SET `status` = 1 WHERE `id` = \'%s\'', $rEvents['id']);
+                                    $ipTV_db->query('UPDATE `mag_events` SET `status` = 1 WHERE `id` = ?', $rEvents['id']);
                                 }
                             }
 
@@ -539,7 +539,7 @@ switch ($rReqType) {
                             }
 
                             $rActiveID = ipTV_lib::$request['event_active_id'];
-                            $ipTV_db->query('UPDATE `mag_events` SET `status` = 1 WHERE `id` = \'%s\'', $rActiveID);
+                            $ipTV_db->query('UPDATE `mag_events` SET `status` = 1 WHERE `id` = ?', $rActiveID);
 
                             exit(json_encode(array('js' => array('data' => 'ok'))));
                     }
@@ -593,7 +593,7 @@ switch ($rReqType) {
                                 $rID = intval(ipTV_lib::$request['id']);
                                 $rRealType = ipTV_lib::$request['real_type'];
                                 $rDate = date('Y-m-d H:i:s');
-                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(\'%s\', \'%s\', \'%s\', \'%s\')', $rID, $rDevice['mag_id'], $rRealType, $rDate);
+                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(?, ?, ?, ?)', $rID, $rDevice['mag_id'], $rRealType, $rDate);
                             }
 
                             exit(json_encode(array('js' => true)));
@@ -602,7 +602,7 @@ switch ($rReqType) {
                             $rChannels = (empty(ipTV_lib::$request['fav_ch']) ? '' : ipTV_lib::$request['fav_ch']);
                             $rChannels = array_filter(array_map('intval', explode(',', $rChannels)));
                             $rDevice['fav_channels']['live'] = $rChannels;
-                            $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                            $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                             updatecache();
 
                             exit(json_encode(array('js' => true)));
@@ -696,7 +696,7 @@ switch ($rReqType) {
 
                             if ($rChannelID > 0) {
                                 $rDevice['last_itv_id'] = $rChannelID;
-                                $ipTV_db->query('UPDATE `mag_devices` SET `last_itv_id` = \'%s\' WHERE `mag_id` = \'%s\'', $rChannelID, $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `last_itv_id` = ? WHERE `mag_id` = ?', $rChannelID, $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -727,7 +727,7 @@ switch ($rReqType) {
                                 $rID = intval(ipTV_lib::$request['id']);
                                 $rRealType = ipTV_lib::$request['real_type'];
                                 $rDate = date('Y-m-d H:i:s');
-                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(\'%s\', \'%s\', \'%s\', \'%s\')', $rID, $rDevice['mag_id'], $rRealType, $rDate);
+                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(?, ?, ?, ?)', $rID, $rDevice['mag_id'], $rRealType, $rDate);
                             }
 
                         case 'set_fav':
@@ -738,7 +738,7 @@ switch ($rReqType) {
                                     $rDevice['fav_channels']['movie'][] = $rVideoID;
                                 }
 
-                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -754,7 +754,7 @@ switch ($rReqType) {
                                         break;
                                     }
                                 }
-                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -831,7 +831,7 @@ switch ($rReqType) {
                                         list($rCommand['series_id'], $rCommand['season_num']) = explode(':', basename($rCommand['series_data'], '.mpg'));
                                     }
 
-                                    $ipTV_db->query('SELECT t1.stream_id,t2.target_container FROM `streams_episodes` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id WHERE t1.`series_id` = \'%s\' AND t1.`season_num` = \'%s\' ORDER BY `episode_num` ASC LIMIT ' . intval($rSeries - 1) . ', 1', $rCommand['series_id'], $rCommand['season_num']);
+                                    $ipTV_db->query('SELECT t1.stream_id,t2.target_container FROM `streams_episodes` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id WHERE t1.`series_id` = ? AND t1.`season_num` = ? ORDER BY `episode_num` ASC LIMIT ' . intval($rSeries - 1) . ', 1', $rCommand['series_id'], $rCommand['season_num']);
 
                                     if (0 < $ipTV_db->num_rows()) {
                                         $rRow = $ipTV_db->get_row();
@@ -867,7 +867,7 @@ switch ($rReqType) {
                                 $rID = intval(ipTV_lib::$request['id']);
                                 $rRealType = ipTV_lib::$request['real_type'];
                                 $rDate = date('Y-m-d H:i:s');
-                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(\'%s\', \'%s\', \'%s\', \'%s\')', $rID, $rDevice['mag_id'], $rRealType, $rDate);
+                                $ipTV_db->query('INSERT INTO `mag_claims` (`stream_id`,`mag_id`,`real_type`,`date`) VALUES(?, ?, ?, ?)', $rID, $rDevice['mag_id'], $rRealType, $rDate);
                             }
 
                             exit(json_encode(array('js' => true)));
@@ -880,7 +880,7 @@ switch ($rReqType) {
                                     $rDevice['fav_channels']['series'][] = $rVideoID;
                                 }
 
-                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -897,7 +897,7 @@ switch ($rReqType) {
                                         break;
                                     }
                                 }
-                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                                $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                                 updatecache();
                             }
 
@@ -980,7 +980,7 @@ switch ($rReqType) {
                             $f3f9f9fa3c58c22b = (empty(ipTV_lib::$request['fav_radio']) ? '' : ipTV_lib::$request['fav_radio']);
                             $f3f9f9fa3c58c22b = array_filter(array_map('intval', explode(',', $f3f9f9fa3c58c22b)));
                             $rDevice['fav_channels']['radio_streams'] = $f3f9f9fa3c58c22b;
-                            $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = \'%s\' WHERE `mag_id` = \'%s\'', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
+                            $ipTV_db->query('UPDATE `mag_devices` SET `fav_channels` = ? WHERE `mag_id` = ?', json_encode($rDevice['fav_channels']), $rDevice['mag_id']);
                             updatecache();
 
                             exit(json_encode(array('js' => true)));
@@ -1107,7 +1107,7 @@ switch ($rReqType) {
                             if (file_exists(STREAMS_TMP_PATH . 'stream_' . intval($rChannelID))) {
                                 $rStreamRow = igbinary_unserialize(file_get_contents(STREAMS_TMP_PATH . 'stream_' . intval($rChannelID)))['info'];
                             } else {
-                                $ipTV_db->query('SELECT `tv_archive_duration` FROM `streams` WHERE `id` = \'%s\';', ipTV_lib::$request['ch_id']);
+                                $ipTV_db->query('SELECT `tv_archive_duration` FROM `streams` WHERE `id` = ?;', ipTV_lib::$request['ch_id']);
 
                                 if ($ipTV_db->num_rows() > 0) {
                                     $rStreamRow = $ipTV_db->get_row();
@@ -1201,7 +1201,7 @@ switch ($rReqType) {
                             if (file_exists(STREAMS_TMP_PATH . 'stream_' . intval($rChannelID))) {
                                 $rStreamRow = igbinary_unserialize(file_get_contents(STREAMS_TMP_PATH . 'stream_' . intval($rChannelID)))['info'];
                             } else {
-                                $ipTV_db->query('SELECT `tv_archive_duration` FROM `streams` WHERE `id` = \'%s\';', ipTV_lib::$request['ch_id']);
+                                $ipTV_db->query('SELECT `tv_archive_duration` FROM `streams` WHERE `id` = ?;', ipTV_lib::$request['ch_id']);
 
                                 if ($ipTV_db->num_rows() > 0) {
                                     $rStreamRow = $ipTV_db->get_row();
@@ -1360,12 +1360,12 @@ function getItems($rTypes = array(), $rCategoryID = null, $rFav = null, $rOrderB
     }
 
     if (!empty($rCategoryID)) {
-        $rWhere[] = "JSON_CONTAINS(`category_id`, '%s', '\$')";
+        $rWhere[] = "JSON_CONTAINS(`category_id`, ?, '\$')";
         $rWhereV[] = $rCategoryID;
     }
 
     if (!empty($rPicking['genre']) && $rPicking['genre'] != '*') {
-        $rWhere[] = "JSON_CONTAINS(`category_id`, '%s', '\$')";
+        $rWhere[] = "JSON_CONTAINS(`category_id`, ?, '\$')";
         $rWhereV[] = $rPicking['genre'];
     }
 
@@ -1384,13 +1384,13 @@ function getItems($rTypes = array(), $rCategoryID = null, $rFav = null, $rOrderB
     }
 
     if (!empty($rSearchBy)) {
-        $rWhere[] = '`stream_display_name` LIKE \'%s\'';
+        $rWhere[] = '`stream_display_name` LIKE ?';
         $rWhereV[] = '%' . $rSearchBy . '%';
     }
 
 
     if (!empty($rPicking['abc']) && $rPicking['abc'] != '*') {
-        $rWhere[] = 'UCASE(LEFT(`stream_display_name`, 1)) = \'%s\'';
+        $rWhere[] = 'UCASE(LEFT(`stream_display_name`, 1)) = ?';
         $rWhereV[] = strtoupper($rPicking['abc']);
     }
 
@@ -1440,7 +1440,7 @@ function getItems($rTypes = array(), $rCategoryID = null, $rFav = null, $rOrderB
             $rRows = $ipTV_db->get_rows();
         } else {
             $rWhereV[] = $additionalOptions;
-            $ipTV_db->query("SELECT * FROM (SELECT @row_number:=@row_number+1 AS `pos`, `id` FROM `streams`, (SELECT @row_number:=0) AS `t` " . $rWhereString . " ORDER BY " . $rOrder . ") `ids` WHERE `ids`.`id` = '%s';", ...$rWhereV);
+            $ipTV_db->query("SELECT * FROM (SELECT @row_number:=@row_number+1 AS `pos`, `id` FROM `streams`, (SELECT @row_number:=0) AS `t` " . $rWhereString . " ORDER BY " . $rOrder . ") `ids` WHERE `ids`.`id` = ?;", ...$rWhereV);
             return $ipTV_db->get_row()["pos"] ?: NULL;
         }
     } else {
@@ -1524,10 +1524,10 @@ function getDevice($rID = null, $rMAC = null) {
 
     if (!$rDevice && $rMAC || $rDevice && 600 < time() - $rDevice['generated']) {
         if ($rMAC) {
-            $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = \'%s\' LIMIT 1', $rMAC);
+            $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = ? LIMIT 1', $rMAC);
         } else {
             if ($rDevice) {
-                $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = \'%s\' LIMIT 1', $rDevice['get_profile_vars']['mac']);
+                $ipTV_db->query('SELECT * FROM `mag_devices` WHERE `mac` = ? LIMIT 1', $rDevice['get_profile_vars']['mac']);
             }
         }
 
@@ -1697,7 +1697,7 @@ function getMovies($rCategoryID = null, $rFav = null, $rOrderBy = null, $rSearch
 
 function getSeasons($rSeriesID) {
     global $ipTV_db;
-    $ipTV_db->query('SELECT * FROM `streams_episodes` t1 INNER JOIN `streams` t2 ON t2.id=t1.stream_id WHERE t1.series_id = \'%s\' ORDER BY t1.season_num DESC, t1.episode_num ASC', $rSeriesID);
+    $ipTV_db->query('SELECT * FROM `streams_episodes` t1 INNER JOIN `streams` t2 ON t2.id=t1.stream_id WHERE t1.series_id = ? ORDER BY t1.season_num DESC, t1.episode_num ASC', $rSeriesID);
 
     return $ipTV_db->get_rows(true, 'season_num', false);
 }
@@ -1714,7 +1714,7 @@ function getSeries($rMovieID = null, $rCategoryID = null, $rFav = null, $rOrderB
         $rItems = getseriesitems($rDevice['user_id'], 'series', $rCategoryID, $rFav, $rOrderBy, $rSearchBy, $rPicking);
     } else {
         $rItems = getSeasons($rMovieID);
-        $ipTV_db->query('SELECT * FROM `streams_series` WHERE `id` = \'%s\'', $rMovieID);
+        $ipTV_db->query('SELECT * FROM `streams_series` WHERE `id` = ?', $rMovieID);
         $rSeriesInfo = $ipTV_db->get_row();
     }
 

--- a/wwwdir/streaming/admin_movie.php
+++ b/wwwdir/streaming/admin_movie.php
@@ -23,9 +23,9 @@ $extension = $stream['extension'];
 $ipTV_db->query('
                     SELECT t1.*
                     FROM `streams` t1
-                    INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.pid IS NOT NULL AND t2.server_id = \'%d\'
+                    INNER JOIN `streams_servers` t2 ON t2.stream_id = t1.id AND t2.pid IS NOT NULL AND t2.server_id = ?
                     INNER JOIN `streams_types` t3 ON t3.type_id = t1.type AND t3.type_key = \'movie\'
-                    WHERE t1.`id` = \'%d\'', SERVER_ID, $stream_id);
+                    WHERE t1.`id` = ?', SERVER_ID, $stream_id);
 if (ipTV_lib::$settings['use_buffer'] == 0) {
     header('X-Accel-Buffering: no');
 }

--- a/wwwdir/streaming/auth.php
+++ b/wwwdir/streaming/auth.php
@@ -343,7 +343,7 @@ if ($rExtension) {
                         if (ipTV_lib::$cached) {
                             ipTV_lib::setSignal('restream_block_user/' . $rUserInfo['id'] . '/' . $streamID . '/' . $IP, 1);
                         } else {
-                            $ipTV_db->query('UPDATE `users` SET `admin_enabled` = 0 WHERE `id` = \'%s\';', $rUserInfo['id']);
+                            $ipTV_db->query('UPDATE `users` SET `admin_enabled` = 0 WHERE `id` = ?;', $rUserInfo['id']);
                         }
                     }
 
@@ -366,7 +366,7 @@ if ($rExtension) {
             if (ipTV_lib::$cached) {
                 ipTV_lib::setSignal('expiring/' . $rUserInfo['id'], time());
             } else {
-                $ipTV_db->query('UPDATE `users` SET `last_expiration_video` = \'%s\' WHERE `id` = \'%s\';', time(), $rUserInfo['id']);
+                $ipTV_db->query('UPDATE `users` SET `last_expiration_video` = ? WHERE `id` = ?;', time(), $rUserInfo['id']);
             }
 
             ipTV_streaming::showVideoServer('show_expiring_video', 'expiring_video_path', $rExtension, $rUserInfo, $IP, $rCountryCode, $rUserInfo['con_isp_name'], SERVER_ID);

--- a/wwwdir/streaming/live.php
+++ b/wwwdir/streaming/live.php
@@ -172,9 +172,9 @@ if ($rChannelInfo) {
                 $rConnection = ipTV_streaming::getConnection($tokenData["uuid"]);
             } else {
                 if (isset($tokenData["adaptive"])) {
-                    $ipTV_db->query("SELECT `activity_id`, `user_ip` FROM `lines_live` WHERE `uuid` = '%s' AND `user_id` = '%s' AND `container` = 'hls' AND `hls_end` = 0", $tokenData["uuid"], $userInfo["id"]);
+                    $ipTV_db->query("SELECT `activity_id`, `user_ip` FROM `lines_live` WHERE `uuid` = ? AND `user_id` = ? AND `container` = 'hls' AND `hls_end` = 0", $tokenData["uuid"], $userInfo["id"]);
                 } else {
-                    $ipTV_db->query("SELECT `activity_id`, `user_ip` FROM `lines_live` WHERE `uuid` = '%s' AND `user_id` = '%s' AND `server_id` = '%s' AND `container` = 'hls' AND `stream_id` = '%s' AND `hls_end` = 0", $tokenData["uuid"], $userInfo["id"], $rServerID, $streamID);
+                    $ipTV_db->query("SELECT `activity_id`, `user_ip` FROM `lines_live` WHERE `uuid` = ? AND `user_id` = ? AND `server_id` = ? AND `container` = 'hls' AND `stream_id` = ? AND `hls_end` = 0", $tokenData["uuid"], $userInfo["id"], $rServerID, $streamID);
                 }
                 if ($ipTV_db->num_rows() > 0) {
                     $rConnection = $ipTV_db->get_row();
@@ -188,7 +188,7 @@ if ($rChannelInfo) {
                     $rConnectionData = ["user_id" => $userInfo["id"], "stream_id" => $streamID, "server_id" => $rServerID, "user_agent" => $rUserAgent, "user_ip" => $rIP, "container" => "hls", "pid" => NULL, "date_start" => $rActivityStart, "geoip_country_code" => $rCountryCode, "isp" => $userInfo["con_isp_name"], "external_device" => $rExternalDevice, "hls_end" => 0, "hls_last_read" => time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], "on_demand" => $rChannelInfo["on_demand"], "identity" => $userInfo["id"], "uuid" => $tokenData["uuid"]];
                     $rResult = ipTV_streaming::createConnection($rConnectionData);
                 } else {
-                    $rResult = $ipTV_db->query("INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`uuid`,`date_start`,`geoip_country_code`,`isp`,`external_device`,`hls_last_read`) VALUES('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s');", $userInfo["id"], $streamID, $rServerID, $rUserAgent, $rIP, "hls", NULL, $tokenData["uuid"], $rActivityStart, $rCountryCode, $userInfo["con_isp_name"], $rExternalDevice, time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"]);
+                    $rResult = $ipTV_db->query("INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`uuid`,`date_start`,`geoip_country_code`,`isp`,`external_device`,`hls_last_read`) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", $userInfo["id"], $streamID, $rServerID, $rUserAgent, $rIP, "hls", NULL, $tokenData["uuid"], $rActivityStart, $rCountryCode, $userInfo["con_isp_name"], $rExternalDevice, time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"]);
                 }
             } else {
                 $rIPMatch = ipTV_lib::$settings["ip_subnet_match"] ? implode(".", array_slice(explode(".", $rConnection["user_ip"]), 0, -1)) == implode(".", array_slice(explode(".", $rIP), 0, -1)) : $rConnection["user_ip"] == $rIP;
@@ -204,7 +204,7 @@ if ($rChannelInfo) {
                         $rResult = false;
                     }
                 } else {
-                    $rResult = $ipTV_db->query("UPDATE `lines_live` SET `hls_last_read` = '%s', `hls_end` = 0, `server_id` = '%s' WHERE `activity_id` = '%s'", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $rServerID, $rConnection["activity_id"]);
+                    $rResult = $ipTV_db->query("UPDATE `lines_live` SET `hls_last_read` = ?, `hls_end` = 0, `server_id` = ? WHERE `activity_id` = ?", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $rServerID, $rConnection["activity_id"]);
                 }
             }
             if (!$rResult) {
@@ -233,7 +233,7 @@ if ($rChannelInfo) {
             if (ipTV_lib::$settings["redis_handler"]) {
                 $rConnection = ipTV_streaming::getConnection($tokenData["uuid"]);
             } else {
-                $ipTV_db->query("SELECT `activity_id`, `pid`, `user_ip` FROM `lines_live` WHERE `uuid` = '%s' AND `user_id` = '%s' AND `server_id` = '%s' AND `container` = '%s' AND `stream_id` = '%s';", $tokenData["uuid"], $userInfo["id"], $rServerID, $rExtension, $streamID);
+                $ipTV_db->query("SELECT `activity_id`, `pid`, `user_ip` FROM `lines_live` WHERE `uuid` = ? AND `user_id` = ? AND `server_id` = ? AND `container` = ? AND `stream_id` = ?;", $tokenData["uuid"], $userInfo["id"], $rServerID, $rExtension, $streamID);
 
                 if ($ipTV_db->num_rows() > 0) {
                     $rConnection = $ipTV_db->get_row();
@@ -247,7 +247,7 @@ if ($rChannelInfo) {
                     $rConnectionData = ["user_id" => $userInfo["id"], "stream_id" => $streamID, "server_id" => $rServerID, "user_agent" => $rUserAgent, "user_ip" => $rIP, "container" => $rExtension, "pid" => $PID, "date_start" => $rActivityStart, "geoip_country_code" => $rCountryCode, "isp" => $userInfo["con_isp_name"], "external_device" => $rExternalDevice, "hls_end" => 0, "hls_last_read" => time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], "on_demand" => $rChannelInfo["on_demand"], "identity" => $userInfo["id"], "uuid" => $tokenData["uuid"]];
                     $rResult = ipTV_streaming::createConnection($rConnectionData);
                 } else {
-                    $rResult = $ipTV_db->query("INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`uuid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')", $userInfo["id"], $streamID, $rServerID, $rUserAgent, $rIP, $rExtension, $PID, $tokenData["uuid"], $rActivityStart, $rCountryCode, $userInfo["con_isp_name"], $rExternalDevice);
+                    $rResult = $ipTV_db->query("INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`uuid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $userInfo["id"], $streamID, $rServerID, $rUserAgent, $rIP, $rExtension, $PID, $tokenData["uuid"], $rActivityStart, $rCountryCode, $userInfo["con_isp_name"], $rExternalDevice);
                 }
             } else {
                 $rIPMatch = ipTV_lib::$settings["ip_subnet_match"] ? implode(".", array_slice(explode(".", $rConnection["user_ip"]), 0, -1)) == implode(".", array_slice(explode(".", $rIP), 0, -1)) : $rConnection["user_ip"] == $rIP;
@@ -266,7 +266,7 @@ if ($rChannelInfo) {
                         $rResult = false;
                     }
                 } else {
-                    $rResult = $ipTV_db->query("UPDATE `lines_live` SET `hls_end` = 0, `hls_last_read` = '%s', `pid` = '%s' WHERE `activity_id` = '%s';", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $PID, $rConnection["activity_id"]);
+                    $rResult = $ipTV_db->query("UPDATE `lines_live` SET `hls_end` = 0, `hls_last_read` = ?, `pid` = ? WHERE `activity_id` = ?;", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $PID, $rConnection["activity_id"]);
                 }
             }
             if (!$rResult) {
@@ -424,16 +424,16 @@ if ($rChannelInfo) {
                     }
                     if (time() - $rLastCheck > 300) {
                         $rLastCheck = time();
-                        $rConnection = NULL;
-                        // ipTV_lib::getCache("settings");
-                        // ipTV_lib::$settings;
+                        $rConnection = null;
+                        ipTV_lib::getCache("settings");
+                        ipTV_lib::$settings;
                         if (ipTV_lib::$settings["redis_handler"]) {
                             ipTV_lib::connectRedis();
                             $rConnection = ipTV_streaming::getConnection($tokenData["uuid"]);
                             ipTV_lib::closeRedis();
                         } else {
                             $ipTV_db->db_connect();
-                            $ipTV_db->query("SELECT `pid`, `hls_end` FROM `lines_live` WHERE `uuid` = '%s'", $tokenData["uuid"]);
+                            $ipTV_db->query("SELECT `pid`, `hls_end` FROM `lines_live` WHERE `uuid` = ?", $tokenData["uuid"]);
                             if ($ipTV_db->num_rows() == 1) {
                                 $rConnection = $ipTV_db->get_row();
                             }
@@ -475,7 +475,7 @@ function shutdown() {
             if (!is_object($ipTV_db)) {
                 $ipTV_db->db_connect();
             }
-            $ipTV_db->query("UPDATE `lines_live` SET `hls_end` = 1, `hls_last_read` = '%s' WHERE `uuid` = '%s' AND `pid` = '%s';", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $tokenData["uuid"], $PID);
+            $ipTV_db->query("UPDATE `lines_live` SET `hls_end` = 1, `hls_last_read` = ? WHERE `uuid` = ? AND `pid` = ?;", time() - (int) ipTV_lib::$Servers[SERVER_ID]["time_offset"], $tokenData["uuid"], $PID);
         }
         ipTV_lib::unlinkFile(CONS_TMP_PATH . $tokenData["uuid"]);
         ipTV_lib::unlinkFile(CONS_TMP_PATH . $streamID . "/" . $tokenData["uuid"]);

--- a/wwwdir/streaming/rtmp.php
+++ b/wwwdir/streaming/rtmp.php
@@ -118,7 +118,7 @@ if ($user_info = ipTV_streaming::getUserInfo(null, $username, $password, true, f
             sleep(5);
         }
         if ($user_info['max_connections'] == 0 || $user_info['active_cons'] < $user_info['max_connections']) {
-            $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES(\'%d\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\')', $user_info['id'], $stream_id, SERVER_ID, '', $user_ip, $extension, ipTV_lib::$request['clientid'], time(), $geoip_country_code, $user_info['con_isp_name'], $external_device);
+            $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES(?,?,?,?,?,?,?,?,?,?,?)', $user_info['id'], $stream_id, SERVER_ID, '', $user_ip, $extension, ipTV_lib::$request['clientid'], time(), $geoip_country_code, $user_info['con_isp_name'], $external_device);
             $activity_id = $ipTV_db->last_insert_id();
             $ipTV_db->close_mysql();
             http_response_code(200);

--- a/wwwdir/streaming/timeshift.php
+++ b/wwwdir/streaming/timeshift.php
@@ -192,12 +192,12 @@ if (!empty($queue)) {
                 }
                 die;
             }
-            $ipTV_db->query('SELECT activity_id,hls_end FROM `lines_live` WHERE `user_id` = \'%d\' AND `server_id` = \'%d\' AND `container` = \'hls\' AND `user_ip` = \'%s\' AND `user_agent` = \'%s\' AND `stream_id` = \'%d\'', $user_info['id'], SERVER_ID, $user_ip, $user_agent, $stream_id);
+            $ipTV_db->query('SELECT activity_id,hls_end FROM `lines_live` WHERE `user_id` = ? AND `server_id` = ? AND `container` = \'hls\' AND `user_ip` = ? AND `user_agent` = ? AND `stream_id` = ?', $user_info['id'], SERVER_ID, $user_ip, $user_agent, $stream_id);
             if ($ipTV_db->num_rows() == 0) {
                 if ($user_info['max_connections'] != 0) {
-                    $ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `user_id` = \'%d\' AND `container` = \'hls\'', $user_info['id']);
+                    $ipTV_db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `user_id` = ? AND `container` = \'hls\'', $user_info['id']);
                 }
-                $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`,`hls_last_read`) VALUES(\'%d\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\',\'%d\')', $user_info['id'], $stream_id, SERVER_ID, $user_agent, $user_ip, $container_priority . ' (HLS)', getmypid(), $date, $geoip_country_code, $user_info['con_isp_name'], $external_device, $date);
+                $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`,`hls_last_read`) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)', $user_info['id'], $stream_id, SERVER_ID, $user_agent, $user_ip, $container_priority . ' (HLS)', getmypid(), $date, $geoip_country_code, $user_info['con_isp_name'], $external_device, $date);
                 $activity_id = $ipTV_db->last_insert_id();
             } else {
                 $row = $ipTV_db->get_row();
@@ -206,7 +206,7 @@ if (!empty($queue)) {
                     die;
                 }
                 $activity_id = $row['activity_id'];
-                $ipTV_db->query('UPDATE `lines_live` SET `hls_last_read` = \'%d\' WHERE `activity_id` = \'%d\'', time(), $row['activity_id']);
+                $ipTV_db->query('UPDATE `lines_live` SET `hls_last_read` = ? WHERE `activity_id` = ?', time(), $row['activity_id']);
             }
             $ipTV_db->close_mysql();
             $output = '#EXTM3U';
@@ -227,7 +227,7 @@ if (!empty($queue)) {
         default:
             header('Content-Type: video/mp2t');
             if (!empty($user_info)) {
-                $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES(\'%d\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\',\'%d\',\'%d\',\'%s\',\'%s\',\'%s\')', $user_info['id'], $stream_id, SERVER_ID, $user_agent, $user_ip, $container_priority, getmypid(), $date, $geoip_country_code, $user_info['con_isp_name'], $external_device);
+                $ipTV_db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`user_agent`,`user_ip`,`container`,`pid`,`date_start`,`geoip_country_code`,`isp`,`external_device`) VALUES(?,?,?,?,?,?,?,?,?,?,?)', $user_info['id'], $stream_id, SERVER_ID, $user_agent, $user_ip, $container_priority, getmypid(), $date, $geoip_country_code, $user_info['con_isp_name'], $external_device);
                 $activity_id = $ipTV_db->last_insert_id();
                 $connection_speed_file = TMP_PATH . $activity_id . '.con';
                 $ipTV_db->close_mysql();

--- a/wwwdir/xplugin.php
+++ b/wwwdir/xplugin.php
@@ -29,7 +29,7 @@ if (!empty(ipTV_lib::$request['action']) && ipTV_lib::$request['action'] == 'aut
         }
         $token = strtoupper(md5(uniqid(rand(), true)));
         $seconds = mt_rand(60, 70);
-        $ipTV_db->query('UPDATE `enigma2_devices` SET `original_mac` = \'%s\',`dns` = \'%s\',`key_auth` = \'%s\',`lversion` = \'%s\',`watchdog_timeout` = \'%d\',`modem_mac` = \'%s\',`local_ip` = \'%s\',`public_ip` = \'%s\',`enigma_version` = \'%s\',`cpu` = \'%s\',`version` = \'%s\',`token` = \'%s\',`last_updated` = \'%d\' WHERE `device_id` = \'%d\'', $cmac, $dn, $user_agent, $lversion, $seconds, $mmac, $ip, $remote_addr, $version, $type, $pversion, $token, time(), $enigma_devices['enigma2']['device_id']);
+        $ipTV_db->query('UPDATE `enigma2_devices` SET `original_mac` = ?,`dns` = ?,`key_auth` = ?,`lversion` = ?,`watchdog_timeout` = ?,`modem_mac` = ?,`local_ip` = ?,`public_ip` = ?,`enigma_version` = ?,`cpu` = ?,`version` = ?,`token` = ?,`last_updated` = ? WHERE `device_id` = ?', $cmac, $dn, $user_agent, $lversion, $seconds, $mmac, $ip, $remote_addr, $version, $type, $pversion, $token, time(), $enigma_devices['enigma2']['device_id']);
         $json['details'] = array();
         $json['details']['token'] = $token;
         $json['details']['username'] = $enigma_devices['user_info']['username'];
@@ -43,7 +43,7 @@ if (empty(ipTV_lib::$request['token'])) {
     die(json_encode(array('valid' => false)));
 }
 $token = ipTV_lib::$request['token'];
-$ipTV_db->query('SELECT * FROM enigma2_devices WHERE `token` = \'%s\' AND `public_ip` = \'%s\' AND `key_auth` = \'%s\' LIMIT 1', $token, $remote_addr, $user_agent);
+$ipTV_db->query('SELECT * FROM enigma2_devices WHERE `token` = ? AND `public_ip` = ? AND `key_auth` = ? LIMIT 1', $token, $remote_addr, $user_agent);
 if ($ipTV_db->num_rows() <= 0) {
     die(json_encode(array('valid' => false)));
 }
@@ -66,8 +66,8 @@ if (!empty($page)) {
             }
         }
     } else {
-        $ipTV_db->query('UPDATE `enigma2_devices` SET `last_updated` = \'%d\',`rc` = \'%d\' WHERE `device_id` = \'%d\'', time(), ipTV_lib::$request['rc'], $device_info['device_id']);
-        $ipTV_db->query('SELECT * FROM `enigma2_actions` WHERE `device_id` = \'%d\'', $device_info['device_id']);
+        $ipTV_db->query('UPDATE `enigma2_devices` SET `last_updated` = ?,`rc` = ? WHERE `device_id` = ?', time(), ipTV_lib::$request['rc'], $device_info['device_id']);
+        $ipTV_db->query('SELECT * FROM `enigma2_actions` WHERE `device_id` = ?', $device_info['device_id']);
         $result = array();
         if ($ipTV_db->num_rows() > 0) {
             $device = $ipTV_db->get_row();
@@ -101,7 +101,7 @@ if (!empty($page)) {
                     $result[$device['key']] = (int) $device['type'];
                     break;
             }
-            $ipTV_db->query('DELETE FROM enigma2_actions where id = \'%d\'', $device['id']);
+            $ipTV_db->query('DELETE FROM enigma2_actions where id = ?', $device['id']);
         }
         die(json_encode(array('valid' => true, 'data' => $result)));
     }


### PR DESCRIPTION
replacing mysqli with pdo

## Summary by Sourcery

Replace mysqli with PDO for database interactions, enhancing security and flexibility. Refactor query execution to use prepared statements, improving security against SQL injection.

Enhancements:
- Replace mysqli with PDO for database interactions to improve security and flexibility.
- Refactor database query execution to use prepared statements, enhancing security against SQL injection.