### PR TITLE
Renamed transcoding_profiles to profiles

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -346,7 +346,7 @@ if (isset(ipTV_lib::$request["action"])) {
             $rProfileID = intval(ipTV_lib::$request["profile_id"]);
             $rSub = ipTV_lib::$request["sub"];
             if ($rSub == "delete") {
-                $ipTV_db_admin->query("DELETE FROM `transcoding_profiles` WHERE `profile_id` = " . intval($rProfileID) . ";");
+                $ipTV_db_admin->query("DELETE FROM `profiles` WHERE `profile_id` = " . intval($rProfileID) . ";");
                 echo json_encode(array("result" => true));
                 exit;
             } else {

--- a/admin/profile.php
+++ b/admin/profile.php
@@ -82,7 +82,7 @@ if (isset(ipTV_lib::$request["submit_profile"])) {
         $rCols = "profile_id," . $rCols;
         $rValues = ipTV_lib::$request["edit"] . "," . $rValues;
     }
-    $rQuery = "REPLACE INTO `transcoding_profiles`(" . $rCols . ") VALUES(" . $rValues . ");";
+    $rQuery = "REPLACE INTO `profiles`(" . $rCols . ") VALUES(" . $rValues . ");";
     if ($ipTV_db_admin->query($rQuery)) {
         if (isset(ipTV_lib::$request["edit"])) {
             $rInsertID = intval(ipTV_lib::$request["edit"]);

--- a/bin/install/database.sql
+++ b/bin/install/database.sql
@@ -1637,21 +1637,21 @@ CREATE TABLE IF NOT EXISTS `tmdb_async` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `transcoding_profiles`
+-- Table structure for table `profiles`
 --
 
-CREATE TABLE IF NOT EXISTS `transcoding_profiles` (
+CREATE TABLE IF NOT EXISTS `profiles` (
   `profile_id` int(11) NOT NULL AUTO_INCREMENT,
-  `profile_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `profile_options` mediumtext COLLATE utf8_unicode_ci NOT NULL,
+  `profile_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `profile_options` mediumtext COLLATE utf8_unicode_ci,
   PRIMARY KEY (`profile_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
--- Dumping data for table `transcoding_profiles`
+-- Dumping data for table `profiles`
 --
 
-INSERT INTO `transcoding_profiles` (`profile_id`, `profile_name`, `profile_options`) VALUES
+INSERT INTO `profiles` (`profile_id`, `profile_name`, `profile_options`) VALUES
 (1, 'Standard H264 AAC', '{\"-vcodec\":\"h264\",\"-acodec\":\"aac\"}');
 
 -- --------------------------------------------------------

--- a/crons/vod.php
+++ b/crons/vod.php
@@ -18,7 +18,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xtreamcodes') {
 
 function loadCron() {
     global $ipTV_db;
-    $ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `transcoding_profiles` t2 ON t2.profile_id = t1.transcode_profile_id WHERE t1.type = 3');
+    $ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `profiles` t2 ON t2.profile_id = t1.transcode_profile_id WHERE t1.type = 3');
     if (0 < $ipTV_db->num_rows()) {
         $streams = $ipTV_db->get_rows();
         foreach ($streams as $stream) {

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -581,7 +581,7 @@ function getStreamArguments() {
 function getTranscodeProfiles() {
     global $ipTV_db_admin;
     $return = array();
-    $ipTV_db_admin->query("SELECT * FROM `transcoding_profiles` ORDER BY `profile_id` ASC;");
+    $ipTV_db_admin->query("SELECT * FROM `profiles` ORDER BY `profile_id` ASC;");
     if ($ipTV_db_admin->num_rows() > 0) {
         foreach ($ipTV_db_admin->get_rows() as $row) {
             $return[] = $row;
@@ -949,7 +949,7 @@ function getPackage($rID) {
 
 function getTranscodeProfile($rID) {
     global $ipTV_db_admin;
-    $ipTV_db_admin->query("SELECT * FROM `transcoding_profiles` WHERE `profile_id` = " . intval($rID) . ";");
+    $ipTV_db_admin->query("SELECT * FROM `profiles` WHERE `profile_id` = " . intval($rID) . ";");
     if ($ipTV_db_admin->num_rows() == 1) {
         return $ipTV_db_admin->get_row();
     }

--- a/includes/cli_tool/update_bd.php
+++ b/includes/cli_tool/update_bd.php
@@ -7,6 +7,7 @@ $ipTV_db->query("CREATE TABLE IF NOT EXISTS `queue` (`id` int(11) NOT NULL AUTO_
 $ipTV_db->query("CREATE TABLE IF NOT EXISTS `rtmp_ips` (`id` int(11) NOT NULL AUTO_INCREMENT, `ip` varchar(255) DEFAULT NULL, `password` varchar(128) DEFAULT NULL, `notes` mediumtext, `push` tinyint(1) DEFAULT NULL, `pull` tinyint(1) DEFAULT NULL, PRIMARY KEY (`id`), UNIQUE KEY `ip` (`ip`)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
 
 $ipTV_db->query("RENAME TABLE `streaming_servers` TO `servers`;");
+$ipTV_db->query("RENAME TABLE `transcoding_profiles` TO `profiles`;");
 
 $ipTV_db->query("ALTER TABLE `servers` ADD COLUMN `sysctl` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL");
 $ipTV_db->query("ALTER TABLE `servers` ADD COLUMN `video_devices` mediumtext COLLATE utf8_unicode_ci");

--- a/includes/stream.php
+++ b/includes/stream.php
@@ -11,7 +11,7 @@ class ipTV_stream {
      * @return int Returns 1 if the stream is successfully transcoded and built, 2 if there are no PIDs for the channel, or 2 if there are no differences in stream sources.
      */
     static function transcodeBuild($streamID) {
-        self::$ipTV_db->query('SELECT * FROM `streams` t1 LEFT JOIN `transcoding_profiles` t3 ON t1.transcode_profile_id = t3.profile_id WHERE t1.`id` = ?', $streamID);
+        self::$ipTV_db->query('SELECT * FROM `streams` t1 LEFT JOIN `profiles` t3 ON t1.transcode_profile_id = t3.profile_id WHERE t1.`id` = ?', $streamID);
         $stream = self::$ipTV_db->get_row();
         $stream['cchannel_rsources'] = json_decode($stream['cchannel_rsources'], true);
         $stream['stream_source'] = json_decode($stream['stream_source'], true);
@@ -112,7 +112,7 @@ class ipTV_stream {
     }
     public static function startMovie($streamID) {
         $stream = array();
-        self::$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_types` t2 ON t2.type_id = t1.type AND t2.live = 0 LEFT JOIN `transcoding_profiles` t4 ON t1.transcode_profile_id = t4.profile_id WHERE t1.direct_source = 0 AND t1.id = ?', $streamID);
+        self::$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_types` t2 ON t2.type_id = t1.type AND t2.live = 0 LEFT JOIN `profiles` t4 ON t1.transcode_profile_id = t4.profile_id WHERE t1.direct_source = 0 AND t1.id = ?', $streamID);
         if (self::$ipTV_db->num_rows() > 0) {
             $stream['stream_info'] = self::$ipTV_db->get_row();
             $target_container = json_decode($stream['stream_info']['target_container'], true);
@@ -241,7 +241,7 @@ class ipTV_stream {
         ipTV_lib::unlinkFile(STREAMS_PATH . $streamID . '_.pid');
 
         $stream = array();
-        self::$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_types` t2 ON t2.type_id = t1.type AND t2.live = 1 LEFT JOIN `transcoding_profiles` t4 ON t1.transcode_profile_id = t4.profile_id WHERE t1.direct_source = 0 AND t1.id = ?', $streamID);
+        self::$ipTV_db->query('SELECT * FROM `streams` t1 INNER JOIN `streams_types` t2 ON t2.type_id = t1.type AND t2.live = 1 LEFT JOIN `profiles` t4 ON t1.transcode_profile_id = t4.profile_id WHERE t1.direct_source = 0 AND t1.id = ?', $streamID);
         if (self::$ipTV_db->num_rows() <= 0) {
             return false;
         }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Renamed the database table `transcoding_profiles` to `profiles` and updated all references to it.